### PR TITLE
APB-9754 Amls CYA

### DIFF
--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/CheckYourAnswersController.scala
@@ -23,19 +23,19 @@ import play.api.mvc.AnyContent
 import play.api.mvc.MessagesControllerComponents
 import uk.gov.hmrc.agentregistrationfrontend.action.Actions
 import uk.gov.hmrc.agentregistrationfrontend.controllers.FrontendController
-import uk.gov.hmrc.agentregistrationfrontend.views.html.SimplePage
+import uk.gov.hmrc.agentregistrationfrontend.views.html.register.amls.CheckYourAnswersPage
 
 @Singleton
 class CheckYourAnswersController @Inject() (
   actions: Actions,
   mcc: MessagesControllerComponents,
-  view: SimplePage // TODO placeholder page
+  view: CheckYourAnswersPage
 )
 extends FrontendController(mcc):
 
   def show: Action[AnyContent] = actions.getApplicationInProgress:
     implicit request =>
-      Ok(view(
-        h1 = "Check your answers placeholder",
-        bodyText = Some("This is a placeholder page for the Check Your Answers page")
-      ))
+      val amlsDetails = request.agentApplication.amlsDetails
+      if amlsDetails.isDefined && amlsDetails.get.isComplete
+      then Ok(view())
+      else Redirect(routes.AmlsSupervisorController.show) // TODO: redirect to first incomplete page instead

--- a/app/uk/gov/hmrc/agentregistrationfrontend/util/DisplayDate.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/util/DisplayDate.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.util
+
+import play.api.i18n.Lang
+import play.api.mvc.Request
+
+import java.time.format.DateTimeFormatter
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import scala.util.Try
+
+object DisplayDate {
+
+  def displayDateForLang(date: Option[LocalDate])(implicit request: Request[?]): String = {
+    val lang = request.cookies
+      .get("PLAY_LANG")
+      .map(_.value)
+      .getOrElse("en")
+
+    val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM uuuu", Lang(lang).toLocale)
+
+    date.map(_.format(dateFormatter)).getOrElse("")
+  }
+
+  def displayDateForLangFromString(strDate: String)(implicit request: Request[?]): String = {
+    val localDate = Try(LocalDate.parse(strDate))
+    localDate.map(d => displayDateForLang(Some(d))).getOrElse(strDate)
+  }
+
+  def displayInstant(instant: Instant)(implicit request: Request[?]): String = {
+    val localDate = instant.atZone(ZoneId.of("Europe/London")).toLocalDate
+    displayDateForLang(Some(localDate))
+  }
+
+}

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/AmlsExpiryDatePage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/AmlsExpiryDatePage.scala.html
@@ -55,7 +55,7 @@
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
                     content = Text(pageTitle),
-                    classes = "govuk-fieldset__legend--xl",
+                    classes = "govuk-fieldset__legend--l",
                     isPageHeading = true
                 ))
             ))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/AmlsRegistrationNumberPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/AmlsRegistrationNumberPage.scala.html
@@ -53,7 +53,7 @@
             label = Label(
                 content = Text(pageTitle),
                 isPageHeading = true,
-                classes = "govuk-label--xl"
+                classes = "govuk-label--l"
             ),
             classes = "govuk-!-width-one-half"
         ).withFormField(form(key)))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/AmlsSupervisoryBodyPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/AmlsSupervisoryBodyPage.scala.html
@@ -58,7 +58,7 @@
             label = Label(
                 content = Text(pageTitle),
                 isPageHeading = true,
-                classes = "govuk-label--xl"
+                classes = "govuk-label--l"
             ),
             items = Seq(SelectItem(
                 value = Some(""),

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/CheckYourAnswersPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/CheckYourAnswersPage.scala.html
@@ -1,0 +1,153 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
+@import uk.gov.hmrc.agentregistrationfrontend.controllers.amls.routes
+@import uk.gov.hmrc.agentregistrationfrontend.controllers.routes as applicationRoutes
+@import uk.gov.hmrc.agentregistrationfrontend.config.AmlsCodes
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
+@import uk.gov.hmrc.agentregistrationfrontend.util.DisplayDate.displayDateForLang
+@import uk.gov.hmrc.agentregistrationfrontend.action.AgentApplicationRequest
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        govukSummaryList: GovukSummaryList,
+        amlsCodes: AmlsCodes
+)
+
+
+@(implicit
+        request: AgentApplicationRequest[AnyContent],
+        messages: Messages
+)
+
+@key = @{
+    "amlsCheckYourAnswers"
+}
+@title = @{
+    messages(s"$key.title")
+}
+@amlsDetails = @{
+    request.agentApplication.getAmlsDetails
+}
+
+@supervisorRow = @{
+    SummaryListRow(
+        key = Key(
+            content = Text(messages(s"$key.supervisoryBody.label"))
+        ),
+        value = Value(
+            content = Text(
+                amlsCodes.getSupervisoryName(
+                    amlsDetails
+                    .supervisoryBody
+                ).value
+            )
+        ),
+        actions = Some(Actions(
+            items = Seq(
+                ActionItem(
+                    href = s"${routes.AmlsSupervisorController.show}",
+                    content = Text(messages(s"$key.change")),
+                    visuallyHiddenText = Some(messages(s"$key.supervisoryBody.label"))
+                )
+            )
+        ))
+    )
+}
+
+@registrationNumberRow = @{
+    SummaryListRow(
+        key = Key(
+            content = Text(messages(s"$key.registrationNumber.label"))
+        ),
+        value = Value(
+            content = Text(
+                amlsDetails
+                .getRegistrationNumber
+                .value
+            )
+        ),
+        actions = Some(Actions(
+            items = Seq(
+                ActionItem(
+                    href = s"${routes.AmlsRegistrationNumberController.show}",
+                    content = Text(messages(s"$key.change")),
+                    visuallyHiddenText = Some(messages(s"$key.registrationNumber.label"))
+                )
+            )
+        ))
+    )
+}
+
+@expiryDateRow = @{
+    SummaryListRow(
+        key = Key(
+            content = Text(messages(s"$key.expiryDate.label"))
+        ),
+        value = Value(
+            content = Text(if amlsDetails.isHmrc then messages(s"$key.notApplicable") else displayDateForLang(Some(amlsDetails.getAmlsExpiryDate)))
+        ),
+        actions = Some(Actions(
+            items = Seq(
+                ActionItem(
+                    href = s"${routes.AmlsExpiryDateController.show}",
+                    content = Text(messages(s"$key.change")),
+                    visuallyHiddenText = Some(messages(s"$key.expiryDate.label"))
+                )
+            )
+        ))
+    )
+}
+
+@evidenceRow = @{
+    SummaryListRow(
+        key = Key(
+            content = Text(messages(s"$key.evidence.label"))
+        ),
+        value = Value(
+            content = Text(if amlsDetails.isHmrc then messages(s"$key.notApplicable") else amlsDetails.getAmlsEvidenceName)
+        ),
+        actions = Some(Actions(
+            items = Seq(
+                ActionItem(
+                    href = s"${routes.AmlsEvidenceUploadController.show}",
+                    content = Text(messages(s"$key.change")),
+                    visuallyHiddenText = Some(messages(s"$key.evidence.label"))
+                )
+            )
+        ))
+    )
+}
+@commonRows = @{Seq(supervisorRow, registrationNumberRow)}
+@nonHmrcRows = @{Seq(expiryDateRow, evidenceRow)}
+@rows = @{if amlsDetails.isHmrc then commonRows else commonRows ++ nonHmrcRows}
+
+@layout(pageTitle = title) {
+    <h2 class="govuk-caption-l">@messages("amlsDetails.title")</h2>
+    <h1 class="govuk-heading-l">@messages(s"$key.title")</h1>
+    @govukSummaryList(SummaryList(rows))
+    <p class="govuk-body">
+      @govukButton(Button(
+          href = Some(applicationRoutes.AgentApplicationController.taskList.url),
+          content = Text(messages("common.confirmAndContinue"))
+      ))
+    </p>
+
+
+}

--- a/conf/messages
+++ b/conf/messages
@@ -111,6 +111,15 @@ fileUploadProgress.REJECTED=The selected file must be a JPG, JPEG, PNG, TIFF, PD
 fileUploadProgress.TOO_LARGE=The selected file must not be larger than 5MB.
 fileUploadProgress.failed=Your file upload has failed. Try uploading your file again.
 
+## AmlsDetails / Check your answers
+amlsCheckYourAnswers.title = Check your answers
+amlsCheckYourAnswers.supervisoryBody.label = Supervisory body
+amlsCheckYourAnswers.registrationNumber.label = Registration number
+amlsCheckYourAnswers.expiryDate.label = Supervision expiry date
+amlsCheckYourAnswers.notApplicable = n/a
+amlsCheckYourAnswers.evidence.label = Evidence of anti-money laundering supervision
+amlsCheckYourAnswers.change = Change
+
 # Timed out
 timed-out.header = You have been signed out
 timed-out.p1 = You have not done anything for 15 minutes, so we have signed you out to keep your account secure.

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -13,6 +13,7 @@
 ->          /                                                                 prod.Routes
 
 GET         /agent-registration/test-only/show-agent-application              uk.gov.hmrc.agentregistrationfrontend.testOnly.controllers.TestOnlyController.showAgentApplication
+GET         /agent-registration/test-only/set-upload-to-complete              uk.gov.hmrc.agentregistrationfrontend.testOnly.controllers.TestOnlyController.setUploadToComplete()
 
 GET         /agent-registration/test-only/grs-stub/:businessType              uk.gov.hmrc.agentregistrationfrontend.testOnly.controllers.GrsStubController.showGrsData(businessType: BusinessType, journeyId: String)
 POST        /agent-registration/test-only/grs-stub/:businessType              uk.gov.hmrc.agentregistrationfrontend.testOnly.controllers.GrsStubController.submitGrsData(businessType: BusinessType, journeyId: String)

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/CheckYourAnswersControllerSpec.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.amls
+
+import com.google.inject.AbstractModule
+import com.softwaremill.quicklens.*
+import play.api.libs.ws.DefaultBodyReadables.*
+import play.api.libs.ws.WSResponse
+import uk.gov.hmrc.agentregistration.shared.AgentApplication
+import uk.gov.hmrc.agentregistration.shared.AmlsCode
+import uk.gov.hmrc.agentregistration.shared.AmlsDetails
+import uk.gov.hmrc.agentregistration.shared.AmlsRegistrationNumber
+import uk.gov.hmrc.agentregistrationfrontend.config.AmlsCodes
+import uk.gov.hmrc.agentregistrationfrontend.services.ApplicationFactory
+import uk.gov.hmrc.agentregistrationfrontend.testsupport.ControllerSpec
+import uk.gov.hmrc.agentregistrationfrontend.testsupport.wiremock.stubs.AgentRegistrationStubs
+import uk.gov.hmrc.agentregistrationfrontend.testsupport.wiremock.stubs.AuthStubs
+
+class CheckYourAnswersControllerSpec
+extends ControllerSpec:
+
+  override lazy val overridesModule: AbstractModule =
+    new AbstractModule:
+      override def configure(): Unit = bind(classOf[AmlsCodes]).asEagerSingleton()
+
+  private val applicationFactory = app.injector.instanceOf[ApplicationFactory]
+  private val path = "/agent-registration/register/anti-money-laundering/check-your-answers"
+
+  "route should have correct path and method" in:
+    routes.CheckYourAnswersController.show shouldBe Call(
+      method = "GET",
+      url = path
+    )
+
+  // when the supervisory body is HMRC, the registration number has a different format to non-HMRC bodies
+  // and no evidence or expiry date is required to be considered complete
+  private val completeHmrcApplication: AgentApplication = applicationFactory
+    .makeNewAgentApplication(tdAll.internalUserId)
+    .modify(_.amlsDetails)
+    .setTo(Some(AmlsDetails(
+      supervisoryBody = AmlsCode("HMRC"),
+      amlsRegistrationNumber = Some(AmlsRegistrationNumber("XAML00000123456")),
+      amlsExpiryDate = None,
+      amlsEvidence = None
+    )))
+  private val completeNonHmrcApplication: AgentApplication = applicationFactory
+    .makeNewAgentApplication(tdAll.internalUserId)
+    .modify(_.amlsDetails)
+    .setTo(Some(AmlsDetails(
+      supervisoryBody = AmlsCode("FCA"),
+      amlsRegistrationNumber = Some(AmlsRegistrationNumber("1234567890")),
+      amlsExpiryDate = Some(tdAll.validAmlsExpiryDate),
+      amlsEvidence = Some(tdAll.amlsUploadDetailsSuccess)
+    )))
+  private val incompleteHmrcApplication: AgentApplication = applicationFactory
+    .makeNewAgentApplication(tdAll.internalUserId)
+    .modify(_.amlsDetails)
+    .setTo(Some(AmlsDetails(
+      supervisoryBody = AmlsCode("HMRC"),
+      amlsRegistrationNumber = None
+    )))
+  private val incompleteNonHmrcApplication: AgentApplication = applicationFactory
+    .makeNewAgentApplication(tdAll.internalUserId)
+    .modify(_.amlsDetails)
+    .setTo(Some(AmlsDetails(
+      supervisoryBody = AmlsCode("FCA"),
+      amlsRegistrationNumber = Some(AmlsRegistrationNumber("1234567890")),
+      amlsExpiryDate = Some(tdAll.validAmlsExpiryDate),
+      amlsEvidence = None
+    )))
+
+  private case class TestCaseForCya(
+    application: AgentApplication,
+    amlsType: String,
+    isComplete: Boolean
+  )
+
+  List(
+    TestCaseForCya(
+      application = completeHmrcApplication,
+      amlsType = "HMRC",
+      isComplete = true
+    ),
+    TestCaseForCya(
+      application = completeNonHmrcApplication,
+      amlsType = "non-HMRC",
+      isComplete = true
+    ),
+    TestCaseForCya(
+      application = incompleteHmrcApplication,
+      amlsType = "HMRC",
+      isComplete = false
+    ),
+    TestCaseForCya(
+      application = incompleteNonHmrcApplication,
+      amlsType = "non-HMRC",
+      isComplete = false
+    )
+  ).foreach: testCase =>
+    if testCase.isComplete then
+      s"GET $path with complete amls details should return 200 and render page for ${testCase.amlsType}" in:
+        AuthStubs.stubAuthorise()
+        AgentRegistrationStubs.stubApplicationInProgress(testCase.application)
+        val response: WSResponse = get(path)
+
+        response.status shouldBe 200
+        val doc = response.parseBodyAsJsoupDocument
+        doc.title() shouldBe "Check your answers - Apply for an agent services account - GOV.UK"
+    else
+      s"GET $path with incomplete amls details should redirect to the start of the amls journey for ${testCase.amlsType}" in:
+        AuthStubs.stubAuthorise()
+        AgentRegistrationStubs.stubApplicationInProgress(testCase.application)
+        val response: WSResponse = get(path)
+
+        response.status shouldBe 303
+        response.header("Location").value shouldBe routes.AmlsSupervisorController.show.url

--- a/test/uk/gov/hmrc/agentregistrationfrontend/testsupport/testdata/TdAgentApplication.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/testsupport/testdata/TdAgentApplication.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.agentregistration.shared.ApplicationState
 
 trait TdAgentApplication { dependencies: TdBase =>
 
-  def agentApplicationAfterCreated = AgentApplication(
+  def agentApplicationAfterCreated: AgentApplication = AgentApplication(
     internalUserId = dependencies.internalUserId,
     createdAt = dependencies.instant,
     applicationState = ApplicationState.InProgress,

--- a/test/uk/gov/hmrc/agentregistrationfrontend/testsupport/testdata/TdBase.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/testsupport/testdata/TdBase.scala
@@ -16,12 +16,17 @@
 
 package uk.gov.hmrc.agentregistrationfrontend.testsupport.testdata
 
+import sttp.model.Uri.UriContext
 import uk.gov.hmrc.agentregistration.shared.CompanyProfile
 import uk.gov.hmrc.agentregistration.shared.FullName
 import uk.gov.hmrc.agentregistration.shared.GroupId
 import uk.gov.hmrc.agentregistration.shared.InternalUserId
 import uk.gov.hmrc.agentregistration.shared.Nino
 import uk.gov.hmrc.agentregistration.shared.Utr
+import uk.gov.hmrc.agentregistration.shared.upscan.ObjectStoreUrl
+import uk.gov.hmrc.agentregistration.shared.upscan.Reference
+import uk.gov.hmrc.agentregistration.shared.upscan.UploadDetails
+import uk.gov.hmrc.agentregistration.shared.upscan.UploadStatus
 
 import java.time.format.DateTimeFormatter
 import java.time.Instant
@@ -59,3 +64,13 @@ trait TdBase:
   lazy val postcode = "AA1 1AA"
   lazy val validAmlsExpiryDate: LocalDate = LocalDate.now().plusMonths(6)
   lazy val invalidAmlsExpiryDate: LocalDate = LocalDate.now().plusMonths(13)
+  lazy val amlsUploadDetailsSuccess: UploadDetails = UploadDetails(
+    reference = Reference("test-file-reference"),
+    status = UploadStatus.UploadedSuccessfully(
+      name = "test.pdf",
+      mimeType = "application/pdf",
+      downloadUrl = ObjectStoreUrl(uri"http://example.com/download"),
+      size = Some(12345),
+      checksum = "checksum"
+    )
+  )

--- a/test/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/CheckYourAnswersPageSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/CheckYourAnswersPageSpec.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.views.register.amls
+
+import com.google.inject.AbstractModule
+import com.softwaremill.quicklens.*
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.mvc.AnyContent
+import uk.gov.hmrc.agentregistration.shared.AgentApplication
+import uk.gov.hmrc.agentregistration.shared.AmlsCode
+import uk.gov.hmrc.agentregistration.shared.AmlsDetails
+import uk.gov.hmrc.agentregistration.shared.AmlsRegistrationNumber
+import uk.gov.hmrc.agentregistrationfrontend.action.AgentApplicationRequest
+import uk.gov.hmrc.agentregistrationfrontend.config.AmlsCodes
+import uk.gov.hmrc.agentregistrationfrontend.services.ApplicationFactory
+import uk.gov.hmrc.agentregistrationfrontend.testsupport.ViewSpec
+import uk.gov.hmrc.agentregistrationfrontend.testsupport.testdata.TdAll
+import uk.gov.hmrc.agentregistrationfrontend.views.html.register.amls.CheckYourAnswersPage
+
+import java.time.LocalDate
+
+class CheckYourAnswersPageSpec
+extends ViewSpec:
+
+  override lazy val overridesModule: AbstractModule =
+    new AbstractModule:
+      override def configure(): Unit = bind(classOf[AmlsCodes]).asEagerSingleton()
+
+  val viewTemplate: CheckYourAnswersPage = app.injector.instanceOf[CheckYourAnswersPage]
+
+  private val tdAll: TdAll = TdAll()
+  private val applicationFactory = app.injector.instanceOf[ApplicationFactory]
+  private val fixedExpiryDate: LocalDate = LocalDate.of(2026, 9, 2)
+
+  private val completeHmrcApplication: AgentApplication = applicationFactory
+    .makeNewAgentApplication(tdAll.internalUserId)
+    .modify(_.amlsDetails)
+    .setTo(Some(AmlsDetails(
+      supervisoryBody = AmlsCode("HMRC"),
+      amlsRegistrationNumber = Some(AmlsRegistrationNumber("XAML00000123456")),
+      amlsExpiryDate = None,
+      amlsEvidence = None
+    )))
+  private val completeNonHmrcApplication: AgentApplication = applicationFactory
+    .makeNewAgentApplication(tdAll.internalUserId)
+    .modify(_.amlsDetails)
+    .setTo(Some(AmlsDetails(
+      supervisoryBody = AmlsCode("FCA"),
+      amlsRegistrationNumber = Some(AmlsRegistrationNumber("1234567890")),
+      amlsExpiryDate = Some(fixedExpiryDate),
+      amlsEvidence = Some(tdAll.amlsUploadDetailsSuccess)
+    )))
+
+  private val heading: String = "Check your answers"
+
+  "CheckYourAnswersPage for complete Hmrc Amls Details" should:
+    implicit val agentApplicationHmrcRequest: AgentApplicationRequest[AnyContent] =
+      new AgentApplicationRequest(
+        request = request,
+        agentApplication = completeHmrcApplication,
+        internalUserId = tdAll.internalUserId,
+        groupId = tdAll.groupId
+      )
+
+    val doc: Document = Jsoup.parse(viewTemplate().body)
+    "contain content" in:
+      doc.mainContent shouldContainContent
+        """
+          |Anti-money laundering supervision details
+          |Check your answers
+          |Supervisory body
+          |HM Revenue and Customs (HMRC)
+          |Change Supervisory body
+          |Registration number
+          |XAML00000123456
+          |Change Registration number
+          """.stripMargin
+
+    "have the correct title" in:
+      doc.title() shouldBe s"$heading - Apply for an agent services account - GOV.UK"
+
+    "render a summary row for each required answer" in:
+      val expectedSummaryList: TestSummaryList = TestSummaryList(
+        List(
+          TestSummaryRow(
+            key = "Supervisory body",
+            value = "HM Revenue and Customs (HMRC)",
+            action = "/agent-registration/register/anti-money-laundering/supervisor-name"
+          ),
+          TestSummaryRow(
+            key = "Registration number",
+            value = "XAML00000123456",
+            action = "/agent-registration/register/anti-money-laundering/registration-number"
+          )
+        )
+      )
+      doc.mainContent.extractSummaryList() shouldBe expectedSummaryList
+
+    "render a confirm and continue button" in:
+      doc.extractLinkButton(1).text shouldBe "Confirm and continue"
+
+  "CheckYourAnswersPage for complete non-Hmrc Amls Details" should:
+    implicit val agentApplicationHmrcRequest: AgentApplicationRequest[AnyContent] =
+      new AgentApplicationRequest(
+        request = request,
+        agentApplication = completeNonHmrcApplication,
+        internalUserId = tdAll.internalUserId,
+        groupId = tdAll.groupId
+      )
+
+    val doc: Document = Jsoup.parse(viewTemplate().body)
+    "contain content" in:
+      doc.mainContent shouldContainContent
+        """
+          |Anti-money laundering supervision details
+          |Check your answers
+          |Supervisory body
+          |Financial Conduct Authority (FCA)
+          |Change Supervisory body
+          |Registration number
+          |1234567890
+          |Change Registration number
+          |Supervision expiry date
+          |2 September 2026
+          |Change Supervision expiry date
+          |Evidence of anti-money laundering supervision
+          |test.pdf
+          |Change Evidence of anti-money laundering supervision
+          """.stripMargin
+
+    "have the correct title" in:
+      doc.title() shouldBe s"$heading - Apply for an agent services account - GOV.UK"
+
+    "render a summary row for each required answer" in:
+      val expectedSummaryList: TestSummaryList = TestSummaryList(
+        List(
+          TestSummaryRow(
+            key = "Supervisory body",
+            value = "Financial Conduct Authority (FCA)",
+            action = "/agent-registration/register/anti-money-laundering/supervisor-name"
+          ),
+          TestSummaryRow(
+            key = "Registration number",
+            value = "1234567890",
+            action = "/agent-registration/register/anti-money-laundering/registration-number"
+          ),
+          TestSummaryRow(
+            key = "Supervision expiry date",
+            value = "2 September 2026",
+            action = "/agent-registration/register/anti-money-laundering/supervision-runs-out"
+          ),
+          TestSummaryRow(
+            key = "Evidence of anti-money laundering supervision",
+            value = "test.pdf",
+            action = "/agent-registration/register/anti-money-laundering/evidence"
+          )
+        )
+      )
+      doc.mainContent.extractSummaryList() shouldBe expectedSummaryList
+
+    "render a confirm and continue button" in:
+      doc.extractLinkButton(1).text shouldBe "Confirm and continue"


### PR DESCRIPTION
This pull request includes a new testOnly endpoint to enable the current user to mark an upload as complete, this enables the journey post upload to proceed to CYA.

Also included is a new method on AmlsDetails for checking if the section is complete to ensure the CYA page can only be rendered if true. I have proposed that we go back to the beginning of the AMLS details journey if not complete as this guarantees a user can get to complete. I know we are thinking about a broader state management solution for task list status values hence did not want to pre-empt that here yet.

Also a small tweak to the heading sizes throughout - they should be set to Large instead of Extra Large so this PR also fixes the other pages in the AMLS details section.