### PR TITLE
APB-9881 Capture Business Type (pre login)

### DIFF
--- a/app/uk/gov/hmrc/agentregistration/shared/AgentType.scala
+++ b/app/uk/gov/hmrc/agentregistration/shared/AgentType.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.agentregistration.shared
 
 import play.api.libs.json.Format
 import play.api.mvc.PathBindable
-import play.api.mvc.QueryStringBindable
 import uk.gov.hmrc.agentregistration.shared.util.EnumBinder
 import uk.gov.hmrc.agentregistration.shared.util.EnumFormat
 
@@ -31,4 +30,3 @@ object AgentType:
 
   given Format[AgentType] = EnumFormat.enumFormat[AgentType]
   given PathBindable[AgentType] = EnumBinder.pathBindable[AgentType]
-  given QueryStringBindable[AgentType] = EnumBinder.queryStringEnumBinder[AgentType]

--- a/app/uk/gov/hmrc/agentregistration/shared/AgentType.scala
+++ b/app/uk/gov/hmrc/agentregistration/shared/AgentType.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.agentregistration.shared
 
 import play.api.libs.json.Format
 import play.api.mvc.PathBindable
+import play.api.mvc.QueryStringBindable
 import uk.gov.hmrc.agentregistration.shared.util.EnumBinder
 import uk.gov.hmrc.agentregistration.shared.util.EnumFormat
 
@@ -26,5 +27,8 @@ enum AgentType:
   case UkTaxAgent
   case NonUkTaxAgent
 
+object AgentType:
+
   given Format[AgentType] = EnumFormat.enumFormat[AgentType]
   given PathBindable[AgentType] = EnumBinder.pathBindable[AgentType]
+  given QueryStringBindable[AgentType] = EnumBinder.queryStringEnumBinder[AgentType]

--- a/app/uk/gov/hmrc/agentregistrationfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/config/AppConfig.scala
@@ -76,7 +76,7 @@ class AppConfig @Inject() (
   val incorpIdBaseUrl: String = servicesConfig.baseUrl("incorporated-entity-identification-frontend")
   val partnershipIdBaseUrl: String = servicesConfig.baseUrl("partnership-identification-frontend")
 
-  def grsJourneyCallbackUrl(businessType: BusinessType) = s"$thisFrontendBaseUrl/agent-registration/register/grs-callback/${businessType.toStringHyphenated}"
+  def grsJourneyCallbackUrl(businessType: BusinessType) = s"$thisFrontendBaseUrl/agent-registration/apply/grs-callback/${businessType.toStringHyphenated}"
 
   def grsJourneyUrl(businessType: BusinessType): String =
     businessType match {

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/AgentTypeController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/AgentTypeController.scala
@@ -53,7 +53,7 @@ extends FrontendController(mcc):
         (agentType: AgentType) =>
           if agentType == AgentType.UkTaxAgent
           then
-            Redirect(routes.BusinessTypeController.show.url)
+            Redirect(routes.BusinessTypeSessionController.show.url)
               .addAgentTypeToSession(agentType)
           else Redirect(applicationRoutes.AgentApplicationController.genericExitPage.url)
       )

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeController.scala
@@ -16,11 +16,16 @@
 
 package uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness
 
+import play.api.data.Form
 import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import play.api.mvc.MessagesControllerComponents
 import uk.gov.hmrc.agentregistrationfrontend.controllers.FrontendController
-import uk.gov.hmrc.agentregistrationfrontend.views.html.SimplePage
+import uk.gov.hmrc.agentregistrationfrontend.controllers.routes as applicationRoutes
+import uk.gov.hmrc.agentregistrationfrontend.forms.BusinessTypeSessionForm
+import uk.gov.hmrc.agentregistrationfrontend.model.BusinessTypeSessionValue
+import uk.gov.hmrc.agentregistrationfrontend.services.SessionService.*
+import uk.gov.hmrc.agentregistrationfrontend.views.html.register.aboutyourbusiness.BusinessTypeSessionPage
 
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -28,13 +33,38 @@ import javax.inject.Singleton
 @Singleton
 class BusinessTypeController @Inject() (
   mcc: MessagesControllerComponents,
-  view: SimplePage
+  businessTypeSessionPage: BusinessTypeSessionPage
 )
 extends FrontendController(mcc):
 
   def show: Action[AnyContent] = Action:
     implicit request =>
-      Ok(view(
-        h1 = "Placeholder for Business Type page...",
-        bodyText = Some("Business Type page content goes here...")
-      ))
+      // ensure that agent type has been selected before allowing business type to be selected
+      if request.readAgentType.isEmpty then
+        Redirect(routes.AgentTypeController.show)
+      else
+        val form: Form[BusinessTypeSessionValue] =
+          request.readBusinessType match
+            case Some(bt: BusinessTypeSessionValue) => BusinessTypeSessionForm.form.fill(bt)
+            case None => BusinessTypeSessionForm.form
+        Ok(businessTypeSessionPage(form))
+
+  def submit: Action[AnyContent] = Action:
+    implicit request =>
+      // ensure that agent type has been selected before allowing business type to be posted
+      if request.readAgentType.isEmpty then
+        Redirect(routes.AgentTypeController.show)
+      else
+        BusinessTypeSessionForm.form.bindFromRequest().fold(
+          formWithErrors => BadRequest(businessTypeSessionPage(formWithErrors)),
+          (businessType: BusinessTypeSessionValue) =>
+            if businessType == BusinessTypeSessionValue.PartnershipType then
+              Redirect(routes.PartnershipTypeController.show.url)
+                .addBusinessTypeToSession(businessType)
+            else if businessType == BusinessTypeSessionValue.NotSupported then
+              Redirect(applicationRoutes.AgentApplicationController.genericExitPage.url)
+                .addBusinessTypeToSession(businessType)
+            else
+              Redirect(applicationRoutes.AgentApplicationController.genericExitPage.url)
+                .addBusinessTypeToSession(businessType) // TODO SoleTrader or LimitedCompany journeys not yet built
+        )

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionController.scala
@@ -20,6 +20,7 @@ import play.api.data.Form
 import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.agentregistration.shared.util.SafeEquals.===
 import uk.gov.hmrc.agentregistrationfrontend.controllers.FrontendController
 import uk.gov.hmrc.agentregistrationfrontend.controllers.routes as applicationRoutes
 import uk.gov.hmrc.agentregistrationfrontend.forms.BusinessTypeSessionForm
@@ -58,10 +59,10 @@ extends FrontendController(mcc):
         BusinessTypeSessionForm.form.bindFromRequest().fold(
           formWithErrors => BadRequest(businessTypeSessionPage(formWithErrors)),
           (businessType: BusinessTypeSessionValue) =>
-            if businessType == BusinessTypeSessionValue.PartnershipType then
+            if businessType === BusinessTypeSessionValue.PartnershipType then
               Redirect(routes.PartnershipTypeController.show.url)
                 .addBusinessTypeToSession(businessType)
-            else if businessType == BusinessTypeSessionValue.NotSupported then
+            else if businessType === BusinessTypeSessionValue.NotSupported then
               Redirect(applicationRoutes.AgentApplicationController.genericExitPage.url)
                 .addBusinessTypeToSession(businessType)
             else

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionController.scala
@@ -31,7 +31,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class BusinessTypeController @Inject() (
+class BusinessTypeSessionController @Inject() (
   mcc: MessagesControllerComponents,
   businessTypeSessionPage: BusinessTypeSessionPage
 )

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/PartnershipTypeController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/PartnershipTypeController.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness
+
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.agentregistrationfrontend.controllers.FrontendController
+import uk.gov.hmrc.agentregistrationfrontend.views.html.SimplePage
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PartnershipTypeController @Inject() (
+  mcc: MessagesControllerComponents,
+  view: SimplePage
+)
+extends FrontendController(mcc):
+
+  def show: Action[AnyContent] = Action:
+    implicit request =>
+      Ok(view(
+        h1 = "Placeholder for partnership type",
+        bodyText = Some("This is a placeholder for the Partnership Type page.")
+      ))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsEvidenceUploadController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsEvidenceUploadController.scala
@@ -63,7 +63,7 @@ with I18nSupport:
         upscanInitiateResponse <- upscanInitiateConnector.initiate(
           redirectOnSuccess = Some(appConfig.upscanRedirectBase + routes.AmlsEvidenceUploadController.showResult.url),
           // cannot use controller.routes for the error url because upscan will respond with query parameters
-          redirectOnError = Some(appConfig.upscanRedirectBase + "/agent-registration/register/anti-money-laundering/evidence/error"),
+          redirectOnError = Some(appConfig.upscanRedirectBase + "/agent-registration/apply/anti-money-laundering/evidence/error"),
           maxFileSize = appConfig.maxFileSize
         )
         // store the upscan fileReference in the application

--- a/app/uk/gov/hmrc/agentregistrationfrontend/forms/BusinessTypeSessionForm.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/forms/BusinessTypeSessionForm.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.forms
+
+import play.api.data.FieldMapping
+import play.api.data.Form
+import play.api.data.Forms
+import play.api.data.Forms.mapping
+import uk.gov.hmrc.agentregistrationfrontend.model.BusinessTypeSessionValue
+import uk.gov.hmrc.agentregistrationfrontend.forms.formatters.EnumFormatter
+import uk.gov.hmrc.agentregistrationfrontend.forms.helpers.ErrorKeys
+
+object BusinessTypeSessionForm:
+
+  val key: String = "businessType"
+  val form: Form[BusinessTypeSessionValue] =
+    val fieldMapping: FieldMapping[BusinessTypeSessionValue] = Forms.of(EnumFormatter.formatter[BusinessTypeSessionValue](
+      errorMessageIfMissing = ErrorKeys.requiredFieldErrorMessage(key),
+      errorMessageIfEnumError = ErrorKeys.invalidInputErrorMessage(key)
+    ))
+    Form(
+      mapping = mapping(key -> fieldMapping)(identity)(Some(_))
+    )

--- a/app/uk/gov/hmrc/agentregistrationfrontend/model/BusinessTypeSessionValue.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/model/BusinessTypeSessionValue.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.agentregistrationfrontend.model
 
 import play.api.libs.json.Format
 import play.api.mvc.PathBindable
-import play.api.mvc.QueryStringBindable
 import uk.gov.hmrc.agentregistration.shared.BusinessType
 import uk.gov.hmrc.agentregistration.shared.util.EnumBinder
 import uk.gov.hmrc.agentregistration.shared.util.EnumFormat
@@ -45,4 +44,3 @@ object BusinessTypeSessionValue:
 
   given Format[BusinessTypeSessionValue] = EnumFormat.enumFormat[BusinessTypeSessionValue]
   given PathBindable[BusinessTypeSessionValue] = EnumBinder.pathBindable[BusinessTypeSessionValue]
-  given QueryStringBindable[BusinessTypeSessionValue] = EnumBinder.queryStringEnumBinder[BusinessTypeSessionValue]

--- a/app/uk/gov/hmrc/agentregistrationfrontend/model/BusinessTypeSessionValue.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/model/BusinessTypeSessionValue.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.model
+
+import play.api.libs.json.Format
+import uk.gov.hmrc.agentregistration.shared.BusinessType
+import uk.gov.hmrc.agentregistration.shared.util.EnumFormat
+
+enum BusinessTypeSessionValue:
+
+  case SoleTrader
+  extends BusinessTypeSessionValue
+  case LimitedCompany
+  extends BusinessTypeSessionValue
+  case PartnershipType
+  extends BusinessTypeSessionValue
+  case NotSupported
+  extends BusinessTypeSessionValue
+
+  def toBusinessType: Option[BusinessType] =
+    this match
+      case SoleTrader => Some(BusinessType.SoleTrader)
+      case LimitedCompany => Some(BusinessType.LimitedCompany)
+      case PartnershipType => None
+      case NotSupported => None
+
+  given Format[BusinessTypeSessionValue] = EnumFormat.enumFormat[BusinessTypeSessionValue]

--- a/app/uk/gov/hmrc/agentregistrationfrontend/model/BusinessTypeSessionValue.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/model/BusinessTypeSessionValue.scala
@@ -17,7 +17,10 @@
 package uk.gov.hmrc.agentregistrationfrontend.model
 
 import play.api.libs.json.Format
+import play.api.mvc.PathBindable
+import play.api.mvc.QueryStringBindable
 import uk.gov.hmrc.agentregistration.shared.BusinessType
+import uk.gov.hmrc.agentregistration.shared.util.EnumBinder
 import uk.gov.hmrc.agentregistration.shared.util.EnumFormat
 
 enum BusinessTypeSessionValue:
@@ -38,4 +41,8 @@ enum BusinessTypeSessionValue:
       case PartnershipType => None
       case NotSupported => None
 
+object BusinessTypeSessionValue:
+
   given Format[BusinessTypeSessionValue] = EnumFormat.enumFormat[BusinessTypeSessionValue]
+  given PathBindable[BusinessTypeSessionValue] = EnumBinder.pathBindable[BusinessTypeSessionValue]
+  given QueryStringBindable[BusinessTypeSessionValue] = EnumBinder.queryStringEnumBinder[BusinessTypeSessionValue]

--- a/app/uk/gov/hmrc/agentregistrationfrontend/services/SessionService.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/services/SessionService.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.agentregistrationfrontend.services
 import play.api.mvc.Request
 import play.api.mvc.Result
 import uk.gov.hmrc.agentregistration.shared.AgentType
-import uk.gov.hmrc.agentregistration.shared.BusinessType
 import uk.gov.hmrc.agentregistration.shared.util.SafeEquals.===
+import uk.gov.hmrc.agentregistrationfrontend.model.BusinessTypeSessionValue
 
 object SessionService:
 
@@ -31,7 +31,7 @@ object SessionService:
   extension (r: Result)
 
     def addAgentTypeToSession(at: AgentType)(implicit request: Request[?]): Result = r.addingToSession(agentTypeKey -> at.toString)
-    def addBusinessTypeToSession(bt: BusinessType)(implicit request: Request[?]): Result = r.addingToSession(businessTypeKey -> bt.toString)
+    def addBusinessTypeToSession(bt: BusinessTypeSessionValue)(implicit request: Request[?]): Result = r.addingToSession(businessTypeKey -> bt.toString)
 
   extension (r: Request[?])
 
@@ -41,8 +41,8 @@ object SessionService:
         .find(_.toString === value)
         .getOrElse(throw new RuntimeException(s"Invalid AgentType type in session: '$value'"))
 
-    def readBusinessType: Option[BusinessType] = r.session.get(businessTypeKey).map: value =>
-      BusinessType
+    def readBusinessType: Option[BusinessTypeSessionValue] = r.session.get(businessTypeKey).map: value =>
+      BusinessTypeSessionValue
         .values
         .find(_.toString === value)
-        .getOrElse(throw new RuntimeException(s"Invalid BusinessType type in session: '$value'"))
+        .getOrElse(throw new RuntimeException(s"Invalid BusinessTypeSessionValue type in session: '$value'"))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/testOnly/controllers/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/testOnly/controllers/TestOnlyController.scala
@@ -24,8 +24,11 @@ import uk.gov.hmrc.agentregistrationfrontend.action.Actions
 import uk.gov.hmrc.agentregistrationfrontend.controllers.FrontendController
 import com.softwaremill.quicklens.*
 import sttp.model.Uri.UriContext
+import uk.gov.hmrc.agentregistration.shared.AgentType
 import uk.gov.hmrc.agentregistration.shared.upscan.*
+import uk.gov.hmrc.agentregistrationfrontend.model.BusinessTypeSessionValue
 import uk.gov.hmrc.agentregistrationfrontend.services.ApplicationService
+import uk.gov.hmrc.agentregistrationfrontend.services.SessionService.*
 
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -59,3 +62,17 @@ extends FrontendController(mcc):
             )))
         )
         .map(_ => Ok("upload set to complete"))
+
+  def addAgentTypeToSession(
+    agentType: AgentType
+  ): Action[AnyContent] = Action:
+    implicit request =>
+      Ok("agent type added to session")
+        .addAgentTypeToSession(agentType)
+
+  def addBusinessTypeToSession(
+    businessType: BusinessTypeSessionValue
+  ): Action[AnyContent] = Action:
+    implicit request =>
+      Ok("business type added to session")
+        .addBusinessTypeToSession(businessType)

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/register/aboutyourbusiness/BusinessTypeSessionPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/register/aboutyourbusiness/BusinessTypeSessionPage.scala.html
@@ -14,8 +14,8 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.agentregistration.shared.AgentType
-@import uk.gov.hmrc.agentregistrationfrontend.forms.AgentTypeForm
+@import uk.gov.hmrc.agentregistrationfrontend.model.BusinessTypeSessionValue
+@import uk.gov.hmrc.agentregistrationfrontend.forms.BusinessTypeSessionForm
 @import uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.routes
 @import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits.RichRadios
@@ -27,10 +27,10 @@
         govukButton: GovukButton
 )
 
-@(form: Form[AgentType])(implicit request: Request[?], messages: Messages)
+@(form: Form[BusinessTypeSessionValue])(implicit request: Request[?], messages: Messages)
 
 @key = @{
-    AgentTypeForm.key
+    BusinessTypeSessionForm.key
 }
 @title = @{messages(s"$key.title")}
 @layout(
@@ -38,7 +38,7 @@
     maybeForm = Some(form)
 ) {
     <h2 class="govuk-caption-l">@messages("about-your-business.title")</h2>
-    @formWithCSRF(action = routes.AgentTypeController.submit) {
+    @formWithCSRF(action = routes.BusinessTypeController.submit) {
         @govukRadios(Radios(
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
@@ -47,10 +47,25 @@
                     classes = "govuk-fieldset__legend--l"
                 ))
             )),
-            items = AgentType.values.toSeq.map(agentType =>
+            items = Seq(
                 RadioItem(
-                    content = Text(messages(s"$key.${agentType.toString}")),
-                    value = Some(agentType.toString)
+                    content = Text(messages(s"$key.${BusinessTypeSessionValue.SoleTrader.toString}")),
+                    value = Some(BusinessTypeSessionValue.SoleTrader.toString)
+                ),
+                RadioItem(
+                    content = Text(messages(s"$key.${BusinessTypeSessionValue.LimitedCompany.toString}")),
+                    value = Some(BusinessTypeSessionValue.LimitedCompany.toString)
+                ),
+                RadioItem(
+                    content = Text(messages(s"$key.${BusinessTypeSessionValue.PartnershipType.toString}")),
+                    value = Some(BusinessTypeSessionValue.PartnershipType.toString)
+                ),
+                RadioItem(
+                    divider = Some(messages("common.or"))
+                ),
+                RadioItem(
+                    content = Text(messages(s"$key.${BusinessTypeSessionValue.NotSupported.toString}")),
+                    value = Some(BusinessTypeSessionValue.NotSupported.toString)
                 )
             )
         ).withFormField(form(key)))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/register/aboutyourbusiness/BusinessTypeSessionPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/register/aboutyourbusiness/BusinessTypeSessionPage.scala.html
@@ -38,7 +38,7 @@
     maybeForm = Some(form)
 ) {
     <h2 class="govuk-caption-l">@messages("about-your-business.title")</h2>
-    @formWithCSRF(action = routes.BusinessTypeController.submit) {
+    @formWithCSRF(action = routes.BusinessTypeSessionController.submit) {
         @govukRadios(Radios(
             fieldset = Some(Fieldset(
                 legend = Some(Legend(

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,9 @@ lazy val microservice = Project("agent-registration-frontend", file("."))
     Test / parallelExecution := true,
     routesImport ++= Seq(
       "uk.gov.hmrc.agentregistrationfrontend",
-      "uk.gov.hmrc.agentregistration.shared.BusinessType"
+      "uk.gov.hmrc.agentregistrationfrontend.model.BusinessTypeSessionValue",
+      "uk.gov.hmrc.agentregistration.shared.BusinessType",
+      "uk.gov.hmrc.agentregistration.shared.AgentType"
     )
   )
   .settings(CodeCoverageSettings.settings)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -12,44 +12,44 @@ GET         /timed-out                                                 uk.gov.hm
 
 GET         /application-submitted                                     uk.gov.hmrc.agentregistrationfrontend.controllers.AgentApplicationController.applicationSubmitted
 
-# Register routes
-GET         /register                                                  uk.gov.hmrc.agentregistrationfrontend.controllers.AgentApplicationController.startRegistration
+# Apply to register routes
+GET         /apply                                                  uk.gov.hmrc.agentregistrationfrontend.controllers.AgentApplicationController.startRegistration
 
 ## save and come back later route
-GET         /register/save-and-come-back-later                         uk.gov.hmrc.agentregistrationfrontend.controllers.AgentApplicationController.saveAndComeBackLater
-GET         /register/exit                                             uk.gov.hmrc.agentregistrationfrontend.controllers.AgentApplicationController.genericExitPage
+GET         /apply/save-and-come-back-later                         uk.gov.hmrc.agentregistrationfrontend.controllers.AgentApplicationController.saveAndComeBackLater
+GET         /apply/exit                                             uk.gov.hmrc.agentregistrationfrontend.controllers.AgentApplicationController.genericExitPage
 
 ## About your business routes
-GET         /register/about-your-business/agent-type                   uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.AgentTypeController.show
-POST        /register/about-your-business/agent-type                   uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.AgentTypeController.submit
+GET         /apply/about-your-business/agent-type                   uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.AgentTypeController.show
+POST        /apply/about-your-business/agent-type                   uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.AgentTypeController.submit
 
-GET         /register/about-your-business/business-type                uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.BusinessTypeController.show
-POST        /register/about-your-business/business-type                uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.BusinessTypeController.submit
-GET         /register/about-your-business/partnership-type             uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.PartnershipTypeController.show
+GET         /apply/about-your-business/business-type                uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.BusinessTypeSessionController.show
+POST        /apply/about-your-business/business-type                uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.BusinessTypeSessionController.submit
+GET         /apply/about-your-business/partnership-type             uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.PartnershipTypeController.show
 
 ## About your application routes - DEPRECATED
-GET         /register/about-your-application/business-type             uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.BusinessTypeController.show
-POST        /register/about-your-application/business-type             uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.BusinessTypeController.submit
+GET         /apply/about-your-application/business-type             uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.BusinessTypeController.show
+POST        /apply/about-your-application/business-type             uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.BusinessTypeController.submit
 
-GET         /register/about-your-application/user-role                 uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.UserRoleController.show
-POST        /register/about-your-application/user-role                 uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.UserRoleController.submit
+GET         /apply/about-your-application/user-role                 uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.UserRoleController.show
+POST        /apply/about-your-application/user-role                 uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.UserRoleController.submit
 
-GET         /register/about-your-application/check-your-answers        uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.CheckYourAnswerController.show
-POST        /register/about-your-application/check-your-answers        uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.CheckYourAnswerController.submit
+GET         /apply/about-your-application/check-your-answers        uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.CheckYourAnswerController.show
+POST        /apply/about-your-application/check-your-answers        uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.CheckYourAnswerController.submit
 
 ##GRS routes
-GET         /register/start-grs-journey                                uk.gov.hmrc.agentregistrationfrontend.controllers.GrsController.startGrsJourney
-GET         /register/grs-callback/:businessType                       uk.gov.hmrc.agentregistrationfrontend.controllers.GrsController.journeyCallback(businessType: BusinessType, journeyId: String)
+GET         /apply/start-grs-journey                                uk.gov.hmrc.agentregistrationfrontend.controllers.GrsController.startGrsJourney
+GET         /apply/grs-callback/:businessType                       uk.gov.hmrc.agentregistrationfrontend.controllers.GrsController.journeyCallback(businessType: BusinessType, journeyId: String)
 
 ## Anti Money Laundering routes
-GET         /register/anti-money-laundering/supervisor-name            uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsSupervisorController.show
-POST        /register/anti-money-laundering/supervisor-name            uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsSupervisorController.submit
-GET         /register/anti-money-laundering/registration-number        uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsRegistrationNumberController.show
-POST        /register/anti-money-laundering/registration-number        uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsRegistrationNumberController.submit
-GET         /register/anti-money-laundering/supervision-runs-out       uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsExpiryDateController.show
-POST        /register/anti-money-laundering/supervision-runs-out       uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsExpiryDateController.submit
-GET         /register/anti-money-laundering/evidence                   uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsEvidenceUploadController.show
-GET         /register/anti-money-laundering/evidence/status            uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsEvidenceUploadController.pollResultWithJavaScript
-GET         /register/anti-money-laundering/evidence/upload-result     uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsEvidenceUploadController.showResult
-GET         /register/anti-money-laundering/evidence/upload-error      uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsEvidenceUploadController.showError(errorCode: String, errorMessage: String, errorRequestId: String, key: String)
-GET         /register/anti-money-laundering/check-your-answers         uk.gov.hmrc.agentregistrationfrontend.controllers.amls.CheckYourAnswersController.show
+GET         /apply/anti-money-laundering/supervisor-name            uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsSupervisorController.show
+POST        /apply/anti-money-laundering/supervisor-name            uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsSupervisorController.submit
+GET         /apply/anti-money-laundering/registration-number        uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsRegistrationNumberController.show
+POST        /apply/anti-money-laundering/registration-number        uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsRegistrationNumberController.submit
+GET         /apply/anti-money-laundering/supervision-runs-out       uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsExpiryDateController.show
+POST        /apply/anti-money-laundering/supervision-runs-out       uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsExpiryDateController.submit
+GET         /apply/anti-money-laundering/evidence                   uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsEvidenceUploadController.show
+GET         /apply/anti-money-laundering/evidence/status            uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsEvidenceUploadController.pollResultWithJavaScript
+GET         /apply/anti-money-laundering/evidence/upload-result     uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsEvidenceUploadController.showResult
+GET         /apply/anti-money-laundering/evidence/upload-error      uk.gov.hmrc.agentregistrationfrontend.controllers.amls.AmlsEvidenceUploadController.showError(errorCode: String, errorMessage: String, errorRequestId: String, key: String)
+GET         /apply/anti-money-laundering/check-your-answers         uk.gov.hmrc.agentregistrationfrontend.controllers.amls.CheckYourAnswersController.show

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -24,6 +24,8 @@ GET         /register/about-your-business/agent-type                   uk.gov.hm
 POST        /register/about-your-business/agent-type                   uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.AgentTypeController.submit
 
 GET         /register/about-your-business/business-type                uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.BusinessTypeController.show
+POST        /register/about-your-business/business-type                uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.BusinessTypeController.submit
+GET         /register/about-your-business/partnership-type             uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness.PartnershipTypeController.show
 
 ## About your application routes - DEPRECATED
 GET         /register/about-your-application/business-type             uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourapplication.BusinessTypeController.show

--- a/conf/messages
+++ b/conf/messages
@@ -7,6 +7,7 @@ common.confirmAndContinue = Confirm and continue
 common.saveAndComeBackLater = Save and come back later
 common.tryAgain = Try again
 common.errorPrefix = Error
+common.or = or
 
 # About your application
 about-application.title = About your application
@@ -27,6 +28,8 @@ agentType.error.invalid = Select yes if your agent business is based in the UK
 businessType.title = How is your business set up?
 businessType.SoleTrader = Sole trader
 businessType.LimitedCompany = Limited company
+businessType.PartnershipType = A type of partnership
+businessType.NotSupported = Something else
 businessType.GeneralPartnership = Partnership
 businessType.LimitedLiabilityPartnership = Limited liability partnership
 businessType.other = The business is set up as something else

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -20,3 +20,6 @@ POST        /agent-registration/test-only/grs-stub/:businessType              uk
 GET         /agent-registration/test-only/grs-stub-retrieve                   uk.gov.hmrc.agentregistrationfrontend.testOnly.controllers.GrsStubController.retrieveGrsData(journeyId: String)
 + nocsrf
 POST        /agent-registration/test-only/grs-stub-setup/:businessType        uk.gov.hmrc.agentregistrationfrontend.testOnly.controllers.GrsStubController.setupGrsJourney(businessType: BusinessType)
+
+GET         /agent-registration/test-only/add-agent-type/:agentType           uk.gov.hmrc.agentregistrationfrontend.testOnly.controllers.TestOnlyController.addAgentTypeToSession(agentType: AgentType)
+GET         /agent-registration/test-only/add-business-type/:businessType     uk.gov.hmrc.agentregistrationfrontend.testOnly.controllers.TestOnlyController.addBusinessTypeToSession(businessType: BusinessTypeSessionValue)

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/AgentApplicationControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/AgentApplicationControllerSpec.scala
@@ -24,12 +24,12 @@ import uk.gov.hmrc.agentregistrationfrontend.testsupport.ControllerSpec
 class AgentApplicationControllerSpec
 extends ControllerSpec:
 
-  private val path: String = "/agent-registration/register"
+  private val path: String = "/agent-registration/apply"
 
   "routes should have correct paths and methods" in:
     routes.AgentApplicationController.startRegistration shouldBe Call(
       method = "GET",
-      url = "/agent-registration/register"
+      url = "/agent-registration/apply"
     )
 
   s"GET $path should redirect to business type page" in:

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/GrsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/GrsControllerSpec.scala
@@ -42,8 +42,8 @@ import java.util.UUID
 class GrsControllerSpec
 extends ControllerSpec:
 
-  val grsStartUrl = "/agent-registration/register/start-grs-journey"
-  val grsCallbackUrl = "/agent-registration/register/grs-callback"
+  val grsStartUrl = "/agent-registration/apply/start-grs-journey"
+  val grsCallbackUrl = "/agent-registration/apply/grs-callback"
 
   val applicationFactory: ApplicationFactory = app.injector.instanceOf[ApplicationFactory]
   val testJourneyId: String = UUID.randomUUID().toString

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/GrsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/GrsControllerSpec.scala
@@ -202,7 +202,7 @@ extends ControllerSpec:
       response.status shouldBe SEE_OTHER
       response.header("Location").value shouldBe grsLimitedCompanyJourneyUrl
 
-    "redirect to grs start for a general  partnership" in:
+    "redirect to grs start for a general partnership" in:
       stubAuthorise()
       stubApplicationInProgress(generalPartnershipApplication)
       stubCreateGrsJourney(GeneralPartnership)
@@ -229,7 +229,7 @@ extends ControllerSpec:
       val response = get(grsStartUrl)
 
       response.status shouldBe SEE_OTHER
-      response.header("Location").value shouldBe "/agent-registration/register"
+      response.header("Location").value shouldBe "/agent-registration/apply"
 
   s"GET $grsCallbackUrl" should:
     "store valid data and redirect to next page for a sole trader" in:
@@ -344,7 +344,7 @@ extends ControllerSpec:
       val response = get(s"$grsCallbackUrl/${LimitedCompany.toStringHyphenated}?journeyId=$testJourneyId")
 
       response.status shouldBe SEE_OTHER
-      response.header("Location").value shouldBe "/agent-registration/register"
+      response.header("Location").value shouldBe "/agent-registration/apply"
 
     "redirect to failed to match identifiers if grs data has identifiersMatch = false" in:
       stubAuthorise()

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourapplication/BusinessTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourapplication/BusinessTypeControllerSpec.scala
@@ -29,17 +29,17 @@ class BusinessTypeControllerSpec
 extends ControllerSpec:
 
   private val applicationFactory = app.injector.instanceOf[ApplicationFactory]
-  private val path = "/agent-registration/register/about-your-application/business-type"
+  private val path = "/agent-registration/apply/about-your-application/business-type"
   private val fakeAgentApplication: AgentApplication = applicationFactory.makeNewAgentApplication(tdAll.internalUserId)
 
   "routes should have correct paths and methods" in:
     routes.BusinessTypeController.show shouldBe Call(
       method = "GET",
-      url = "/agent-registration/register/about-your-application/business-type"
+      url = "/agent-registration/apply/about-your-application/business-type"
     )
     routes.BusinessTypeController.submit shouldBe Call(
       method = "POST",
-      url = "/agent-registration/register/about-your-application/business-type"
+      url = "/agent-registration/apply/about-your-application/business-type"
     )
     routes.BusinessTypeController.submit.url shouldBe routes.BusinessTypeController.show.url
 
@@ -61,7 +61,7 @@ extends ControllerSpec:
 
     response.status shouldBe Status.SEE_OTHER
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/register/about-your-application/user-role"
+    response.header("Location").value shouldBe "/agent-registration/apply/about-your-application/user-role"
 
   s"POST $path without valid selection should return 400" in:
     AuthStubs.stubAuthorise()

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourapplication/CheckYourAnswerControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourapplication/CheckYourAnswerControllerSpec.scala
@@ -30,7 +30,7 @@ class CheckYourAnswerControllerSpec
 extends ControllerSpec:
 
   private val applicationFactory = app.injector.instanceOf[ApplicationFactory]
-  private val path = s"/agent-registration/register/about-your-application/check-your-answers"
+  private val path = s"/agent-registration/apply/about-your-application/check-your-answers"
   private val fakeAgentApplication: AgentApplication = applicationFactory
     .makeNewAgentApplication(tdAll.internalUserId)
     .modify(_.aboutYourApplication.businessType).setTo(Some(SoleTrader))
@@ -39,11 +39,11 @@ extends ControllerSpec:
   "routes should have correct paths and methods" in:
     routes.CheckYourAnswerController.show shouldBe Call(
       method = "GET",
-      url = "/agent-registration/register/about-your-application/check-your-answers"
+      url = "/agent-registration/apply/about-your-application/check-your-answers"
     )
     routes.CheckYourAnswerController.submit shouldBe Call(
       method = "POST",
-      url = "/agent-registration/register/about-your-application/check-your-answers"
+      url = "/agent-registration/apply/about-your-application/check-your-answers"
     )
     routes.CheckYourAnswerController.submit.url shouldBe routes.CheckYourAnswerController.show.url
 
@@ -55,7 +55,7 @@ extends ControllerSpec:
     response.status shouldBe Status.OK
     response.parseBodyAsJsoupDocument.title() shouldBe "Check your answers - Apply for an agent services account - GOV.UK"
 
-  "POST /register/about-your-application/check-answer with confirm and continue selection should redirect to the next page" in:
+  "POST /apply/about-your-application/check-answer with confirm and continue selection should redirect to the next page" in:
     AuthStubs.stubAuthorise()
     AgentRegistrationStubs.stubApplicationInProgress(fakeAgentApplication)
     AgentRegistrationStubs.stubUpdateAgentApplication
@@ -63,4 +63,4 @@ extends ControllerSpec:
     val response: WSResponse = post(path)(Map.empty)
 
     response.status shouldBe Status.SEE_OTHER
-    response.header("Location").value shouldBe "/agent-registration/register/start-grs-journey"
+    response.header("Location").value shouldBe "/agent-registration/apply/start-grs-journey"

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourapplication/UserRoleControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourapplication/UserRoleControllerSpec.scala
@@ -29,17 +29,17 @@ class UserRoleControllerSpec
 extends ControllerSpec:
 
   private val applicationFactory = app.injector.instanceOf[ApplicationFactory]
-  private val path = "/agent-registration/register/about-your-application/user-role"
+  private val path = "/agent-registration/apply/about-your-application/user-role"
   private val fakeAgentApplication: AgentApplication = applicationFactory.makeNewAgentApplication(tdAll.internalUserId)
 
   "routes should have correct paths and methods" in:
     routes.UserRoleController.show shouldBe Call(
       method = "GET",
-      url = "/agent-registration/register/about-your-application/user-role"
+      url = "/agent-registration/apply/about-your-application/user-role"
     )
     routes.UserRoleController.submit shouldBe Call(
       method = "POST",
-      url = "/agent-registration/register/about-your-application/user-role"
+      url = "/agent-registration/apply/about-your-application/user-role"
     )
     routes.UserRoleController.submit.url shouldBe routes.UserRoleController.show.url
 
@@ -61,7 +61,7 @@ extends ControllerSpec:
 
     response.status shouldBe Status.SEE_OTHER
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/register/about-your-application/check-your-answers"
+    response.header("Location").value shouldBe "/agent-registration/apply/about-your-application/check-your-answers"
 
   s"POST $path without valid selection should return 400" in:
     AuthStubs.stubAuthorise()

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/AgentTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/AgentTypeControllerSpec.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.agentregistrationfrontend.testsupport.ControllerSpec
 class AgentTypeControllerSpec
 extends ControllerSpec:
 
-  private val path = "/agent-registration/register/about-your-business/agent-type"
+  private val path = "/agent-registration/apply/about-your-business/agent-type"
 
   "routes should have correct paths and methods" in:
     routes.AgentTypeController.show shouldBe Call(
@@ -48,14 +48,14 @@ extends ControllerSpec:
 
     response.status shouldBe Status.SEE_OTHER
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/register/about-your-business/business-type"
+    response.header("Location").value shouldBe "/agent-registration/apply/about-your-business/business-type"
 
   s"POST $path with No should redirect to an exit page" in:
     val response: WSResponse = post(path)(Map(AgentTypeForm.key -> Seq("NonUkTaxAgent")))
 
     response.status shouldBe Status.SEE_OTHER
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/register/exit"
+    response.header("Location").value shouldBe "/agent-registration/apply/exit"
 
   s"POST $path without valid selection should return 400" in:
     val response: WSResponse = post(path)(Map(AgentTypeForm.key -> Seq("")))

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/AgentTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/AgentTypeControllerSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness
 
 import play.api.libs.ws.DefaultBodyReadables.*
 import play.api.libs.ws.WSResponse
+import uk.gov.hmrc.agentregistrationfrontend.controllers.routes as applicationRoutes
 import uk.gov.hmrc.agentregistrationfrontend.forms.AgentTypeForm
 import uk.gov.hmrc.agentregistrationfrontend.testsupport.ControllerSpec
 
@@ -48,14 +49,14 @@ extends ControllerSpec:
 
     response.status shouldBe Status.SEE_OTHER
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/apply/about-your-business/business-type"
+    response.header("Location").value shouldBe routes.BusinessTypeSessionController.show.url
 
   s"POST $path with No should redirect to an exit page" in:
     val response: WSResponse = post(path)(Map(AgentTypeForm.key -> Seq("NonUkTaxAgent")))
 
     response.status shouldBe Status.SEE_OTHER
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/apply/exit"
+    response.header("Location").value shouldBe applicationRoutes.AgentApplicationController.genericExitPage.url
 
   s"POST $path without valid selection should return 400" in:
     val response: WSResponse = post(path)(Map(AgentTypeForm.key -> Seq("")))

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionControllerSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness
+
+import play.api.libs.ws.DefaultBodyReadables.*
+import play.api.libs.ws.WSResponse
+import uk.gov.hmrc.agentregistrationfrontend.forms.BusinessTypeSessionForm
+import uk.gov.hmrc.agentregistrationfrontend.testsupport.ControllerSpec
+
+class BusinessTypeSessionControllerSpec
+extends ControllerSpec:
+
+  private val path = "/agent-registration/apply/about-your-business/business-type"
+
+  "routes should have correct paths and methods" in:
+    routes.BusinessTypeSessionController.show shouldBe Call(
+      method = "GET",
+      url = "/agent-registration/apply/about-your-business/business-type"
+    )
+    routes.BusinessTypeSessionController.submit shouldBe Call(
+      method = "POST",
+      url = "/agent-registration/apply/about-your-business/business-type"
+    )
+    routes.BusinessTypeSessionController.submit.url shouldBe routes.BusinessTypeSessionController.show.url
+
+  s"GET $path should return 200 and render page" in:
+    val response: WSResponse = get(path)
+
+    response.status shouldBe Status.OK
+    response.parseBodyAsJsoupDocument.title() shouldBe "How is your business set up? - Apply for an agent services account - GOV.UK"
+
+  s"POST $path with selection of type of partnership should redirect to the type of partnership page" in:
+    val response: WSResponse = post(path)(Map(BusinessTypeSessionForm.key -> Seq("PartnershipType")))
+
+    response.status shouldBe Status.SEE_OTHER
+    response.body[String] shouldBe ""
+    response.header("Location").value shouldBe "/agent-registration/apply/about-your-business/partnership-type"
+
+  s"POST $path without valid selection should return 400" in:
+    val response: WSResponse = post(path)(Map(BusinessTypeSessionForm.key -> Seq("")))
+
+    response.status shouldBe Status.BAD_REQUEST
+    response.parseBodyAsJsoupDocument.title() shouldBe "Error: How is your business set up? - Apply for an agent services account - GOV.UK"

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionControllerSpec.scala
@@ -43,7 +43,7 @@ extends ControllerSpec:
 
     response.status shouldBe Status.SEE_OTHER
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/apply/about-your-business/agent-type"
+    response.header("Location").value shouldBe routes.AgentTypeController.show.url
 
   s"GET $path with AgentType in session should return 200 and render page" in:
     val stubSession = get(stubAddAgentUrl)
@@ -65,7 +65,7 @@ extends ControllerSpec:
 
     response.status shouldBe Status.SEE_OTHER
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/apply/about-your-business/partnership-type"
+    response.header("Location").value shouldBe routes.PartnershipTypeController.show.url
 
   s"POST $path without valid selection should return 400" in:
     val stubSession = get(stubAddAgentUrl)

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionControllerSpec.scala
@@ -25,33 +25,55 @@ class BusinessTypeSessionControllerSpec
 extends ControllerSpec:
 
   private val path = "/agent-registration/apply/about-your-business/business-type"
+  private val stubAddAgentUrl = "/agent-registration/test-only/add-agent-type/uk-tax-agent"
 
   "routes should have correct paths and methods" in:
     routes.BusinessTypeSessionController.show shouldBe Call(
       method = "GET",
-      url = "/agent-registration/apply/about-your-business/business-type"
+      url = path
     )
     routes.BusinessTypeSessionController.submit shouldBe Call(
       method = "POST",
-      url = "/agent-registration/apply/about-your-business/business-type"
+      url = path
     )
     routes.BusinessTypeSessionController.submit.url shouldBe routes.BusinessTypeSessionController.show.url
 
-  s"GET $path should return 200 and render page" in:
+  s"GET $path without AgentType in session should return 303 and redirect to agent type page" in:
     val response: WSResponse = get(path)
+
+    response.status shouldBe Status.SEE_OTHER
+    response.body[String] shouldBe ""
+    response.header("Location").value shouldBe "/agent-registration/apply/about-your-business/agent-type"
+
+  s"GET $path with AgentType in session should return 200 and render page" in:
+    val stubSession = get(stubAddAgentUrl)
+    val response: WSResponse = get(
+      uri = path,
+      cookies = extractCookies(stubSession)
+    )
 
     response.status shouldBe Status.OK
     response.parseBodyAsJsoupDocument.title() shouldBe "How is your business set up? - Apply for an agent services account - GOV.UK"
 
-  s"POST $path with selection of type of partnership should redirect to the type of partnership page" in:
-    val response: WSResponse = post(path)(Map(BusinessTypeSessionForm.key -> Seq("PartnershipType")))
+  s"POST $path selecting partnership should redirect to the type of partnership page" in:
+    val stubSession = get(stubAddAgentUrl)
+    val response: WSResponse =
+      post(
+        uri = path,
+        cookies = extractCookies(stubSession)
+      )(Map(BusinessTypeSessionForm.key -> Seq("PartnershipType")))
 
     response.status shouldBe Status.SEE_OTHER
     response.body[String] shouldBe ""
     response.header("Location").value shouldBe "/agent-registration/apply/about-your-business/partnership-type"
 
   s"POST $path without valid selection should return 400" in:
-    val response: WSResponse = post(path)(Map(BusinessTypeSessionForm.key -> Seq("")))
+    val stubSession = get(stubAddAgentUrl)
+    val response: WSResponse =
+      post(
+        uri = path,
+        cookies = extractCookies(stubSession)
+      )(Map(BusinessTypeSessionForm.key -> Seq("")))
 
     response.status shouldBe Status.BAD_REQUEST
     response.parseBodyAsJsoupDocument.title() shouldBe "Error: How is your business set up? - Apply for an agent services account - GOV.UK"

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/BusinessTypeSessionControllerSpec.scala
@@ -18,6 +18,8 @@ package uk.gov.hmrc.agentregistrationfrontend.controllers.aboutyourbusiness
 
 import play.api.libs.ws.DefaultBodyReadables.*
 import play.api.libs.ws.WSResponse
+import uk.gov.hmrc.agentregistration.shared.AgentType.UkTaxAgent
+import uk.gov.hmrc.agentregistration.shared.AgentType
 import uk.gov.hmrc.agentregistrationfrontend.forms.BusinessTypeSessionForm
 import uk.gov.hmrc.agentregistrationfrontend.testsupport.ControllerSpec
 
@@ -25,7 +27,6 @@ class BusinessTypeSessionControllerSpec
 extends ControllerSpec:
 
   private val path = "/agent-registration/apply/about-your-business/business-type"
-  private val stubAddAgentUrl = "/agent-registration/test-only/add-agent-type/uk-tax-agent"
 
   "routes should have correct paths and methods" in:
     routes.BusinessTypeSessionController.show shouldBe Call(
@@ -46,21 +47,19 @@ extends ControllerSpec:
     response.header("Location").value shouldBe routes.AgentTypeController.show.url
 
   s"GET $path with AgentType in session should return 200 and render page" in:
-    val stubSession = get(stubAddAgentUrl)
     val response: WSResponse = get(
       uri = path,
-      cookies = extractCookies(stubSession)
+      cookies = addAgentTypeToSession(UkTaxAgent).extractCookies
     )
 
     response.status shouldBe Status.OK
     response.parseBodyAsJsoupDocument.title() shouldBe "How is your business set up? - Apply for an agent services account - GOV.UK"
 
   s"POST $path selecting partnership should redirect to the type of partnership page" in:
-    val stubSession = get(stubAddAgentUrl)
     val response: WSResponse =
       post(
         uri = path,
-        cookies = extractCookies(stubSession)
+        cookies = addAgentTypeToSession(UkTaxAgent).extractCookies
       )(Map(BusinessTypeSessionForm.key -> Seq("PartnershipType")))
 
     response.status shouldBe Status.SEE_OTHER
@@ -68,11 +67,10 @@ extends ControllerSpec:
     response.header("Location").value shouldBe routes.PartnershipTypeController.show.url
 
   s"POST $path without valid selection should return 400" in:
-    val stubSession = get(stubAddAgentUrl)
     val response: WSResponse =
       post(
         uri = path,
-        cookies = extractCookies(stubSession)
+        cookies = addAgentTypeToSession(UkTaxAgent).extractCookies
       )(Map(BusinessTypeSessionForm.key -> Seq("")))
 
     response.status shouldBe Status.BAD_REQUEST

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsEvidenceUploadControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsEvidenceUploadControllerSpec.scala
@@ -43,9 +43,9 @@ extends ControllerSpec:
       override def configure(): Unit = bind(classOf[AmlsCodes]).asEagerSingleton()
 
   private val applicationFactory = app.injector.instanceOf[ApplicationFactory]
-  private val path = "/agent-registration/register/anti-money-laundering/evidence"
-  private val resultPath = "/agent-registration/register/anti-money-laundering/evidence/upload-result"
-  private val uploadErrorPath = "/agent-registration/register/anti-money-laundering/evidence/upload-error"
+  private val path = "/agent-registration/apply/anti-money-laundering/evidence"
+  private val resultPath = "/agent-registration/apply/anti-money-laundering/evidence/upload-result"
+  private val uploadErrorPath = "/agent-registration/apply/anti-money-laundering/evidence/upload-error"
   private val fakeAgentApplication: AgentApplication = applicationFactory
     .makeNewAgentApplication(tdAll.internalUserId)
     .modify(_.amlsDetails)

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsExpiryDateControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsExpiryDateControllerSpec.scala
@@ -34,7 +34,7 @@ class AmlsExpiryDateControllerSpec
 extends ControllerSpec:
 
   private val applicationFactory = app.injector.instanceOf[ApplicationFactory]
-  private val path = "/agent-registration/register/anti-money-laundering/supervision-runs-out"
+  private val path = "/agent-registration/apply/anti-money-laundering/supervision-runs-out"
 
   "routes should have correct paths and methods" in:
     routes.AmlsExpiryDateController.show shouldBe Call(

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsRegistrationNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsRegistrationNumberControllerSpec.scala
@@ -34,16 +34,16 @@ class AmlsRegistrationNumberControllerSpec
 extends ControllerSpec:
 
   private val applicationFactory = app.injector.instanceOf[ApplicationFactory]
-  private val path = "/agent-registration/register/anti-money-laundering/registration-number"
+  private val path = "/agent-registration/apply/anti-money-laundering/registration-number"
 
   "routes should have correct paths and methods" in:
     routes.AmlsRegistrationNumberController.show shouldBe Call(
       method = "GET",
-      url = "/agent-registration/register/anti-money-laundering/registration-number"
+      url = "/agent-registration/apply/anti-money-laundering/registration-number"
     )
     routes.AmlsRegistrationNumberController.submit shouldBe Call(
       method = "POST",
-      url = "/agent-registration/register/anti-money-laundering/registration-number"
+      url = "/agent-registration/apply/anti-money-laundering/registration-number"
     )
     routes.AmlsRegistrationNumberController.submit.url shouldBe routes.AmlsRegistrationNumberController.show.url
 

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsSupervisorControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsSupervisorControllerSpec.scala
@@ -28,17 +28,17 @@ class AmlsSupervisorControllerSpec
 extends ControllerSpec:
 
   private val applicationFactory = app.injector.instanceOf[ApplicationFactory]
-  private val path = "/agent-registration/register/anti-money-laundering/supervisor-name"
+  private val path = "/agent-registration/apply/anti-money-laundering/supervisor-name"
   private val fakeAgentApplication: AgentApplication = applicationFactory.makeNewAgentApplication(tdAll.internalUserId)
 
   "routes should have correct paths and methods" in:
     routes.AmlsSupervisorController.show shouldBe Call(
       method = "GET",
-      url = "/agent-registration/register/anti-money-laundering/supervisor-name"
+      url = "/agent-registration/apply/anti-money-laundering/supervisor-name"
     )
     routes.AmlsSupervisorController.submit shouldBe Call(
       method = "POST",
-      url = "/agent-registration/register/anti-money-laundering/supervisor-name"
+      url = "/agent-registration/apply/anti-money-laundering/supervisor-name"
     )
     routes.AmlsSupervisorController.submit.url shouldBe routes.AmlsSupervisorController.show.url
 
@@ -60,7 +60,7 @@ extends ControllerSpec:
 
     response.status shouldBe 303
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/register/anti-money-laundering/registration-number"
+    response.header("Location").value shouldBe "/agent-registration/apply/anti-money-laundering/registration-number"
 
   s"POST $path with save for later and valid selection should redirect to the saved for later page" in:
     AuthStubs.stubAuthorise()
@@ -74,7 +74,7 @@ extends ControllerSpec:
 
     response.status shouldBe 303
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/register/save-and-come-back-later"
+    response.header("Location").value shouldBe "/agent-registration/apply/save-and-come-back-later"
 
   s"POST $path without valid selection should return 400" in:
     AuthStubs.stubAuthorise()

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/CheckYourAnswersControllerSpec.scala
@@ -38,7 +38,7 @@ extends ControllerSpec:
       override def configure(): Unit = bind(classOf[AmlsCodes]).asEagerSingleton()
 
   private val applicationFactory = app.injector.instanceOf[ApplicationFactory]
-  private val path = "/agent-registration/register/anti-money-laundering/check-your-answers"
+  private val path = "/agent-registration/apply/anti-money-laundering/check-your-answers"
 
   "route should have correct path and method" in:
     routes.CheckYourAnswersController.show shouldBe Call(

--- a/test/uk/gov/hmrc/agentregistrationfrontend/services/SessionServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/services/SessionServiceSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.agentregistrationfrontend.services
 
 import uk.gov.hmrc.agentregistration.shared.AgentType
-import uk.gov.hmrc.agentregistration.shared.BusinessType
+import uk.gov.hmrc.agentregistrationfrontend.model.BusinessTypeSessionValue
 import uk.gov.hmrc.agentregistrationfrontend.testsupport.UnitSpec
 import uk.gov.hmrc.agentregistrationfrontend.testsupport.testdata.TdAll
 import SessionService.*
@@ -35,7 +35,7 @@ extends UnitSpec:
   val result: Result = Ok("").withSession("some-preexisting-key" -> "some-value")
 
   "BusinessType" should:
-    BusinessType.values.foreach: bt =>
+    BusinessTypeSessionValue.values.foreach: bt =>
       s"$bt can be added to the Result and read back from the Request" in:
         val newResult = result
           .addBusinessTypeToSession(bt)

--- a/test/uk/gov/hmrc/agentregistrationfrontend/services/SessionServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/services/SessionServiceSpec.scala
@@ -58,7 +58,7 @@ extends UnitSpec:
           .withSession("agent-registration-frontend.businessType" -> "garbage")
           .readBusinessType
 
-      throwable.getMessage shouldBe "Invalid BusinessType type in session: 'garbage'"
+      throwable.getMessage shouldBe "Invalid BusinessTypeSessionValue type in session: 'garbage'"
 
     "readBusinessType should return None when business type is not present in session" in:
       request.readBusinessType shouldBe None

--- a/test/uk/gov/hmrc/agentregistrationfrontend/testsupport/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/testsupport/ControllerSpec.scala
@@ -16,6 +16,11 @@
 
 package uk.gov.hmrc.agentregistrationfrontend.testsupport
 
+import play.api.libs.ws.WSResponse
+import uk.gov.hmrc.agentregistration.shared.AgentType
+import uk.gov.hmrc.agentregistration.shared.BusinessType
+import uk.gov.hmrc.agentregistration.shared.util.EnumExtensions.*
+
 class ControllerSpec
 extends ISpec,
   WsHelper:
@@ -23,3 +28,9 @@ extends ISpec,
   export viewspecsupport.JsoupSupport.*
   export play.api.mvc.Call
   export play.api.http.Status
+
+  def addAgentTypeToSession(agentType: AgentType): WSResponse = get(s"/agent-registration/test-only/add-agent-type/${agentType.toStringHyphenated}")
+
+  def addBusinessTypeToSession(businessType: BusinessType): WSResponse = get(
+    s"/agent-registration/test-only/add-business-type/${businessType.toStringHyphenated}"
+  )

--- a/test/uk/gov/hmrc/agentregistrationfrontend/testsupport/WsHelper.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/testsupport/WsHelper.scala
@@ -107,8 +107,10 @@ trait WsHelper {
     }
   }
 
-  /** Extract all cookies from a WSResponse for use in subsequent requests. Usage: val cookies = extractCookies(response)
-    */
-  def extractCookies(response: WSResponse): scala.collection.immutable.Seq[WSCookie] = response.cookies.toList
+  extension (response: WSResponse)
+
+    /** Extract all cookies from a WSResponse for use in subsequent requests.
+      */
+    def extractCookies: scala.collection.immutable.Seq[WSCookie] = response.cookies.toList
 
 }

--- a/test/uk/gov/hmrc/agentregistrationfrontend/testsupport/wiremock/stubs/UpscanStubs.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/testsupport/wiremock/stubs/UpscanStubs.scala
@@ -29,8 +29,8 @@ object UpscanStubs {
     s"""
    {
        "callbackUrl": "http://localhost:${WireMockSupport.port}/agent-registration/upscan-callback",
-       "successRedirect": "http://localhost:22201/agent-registration/register/anti-money-laundering/evidence/upload-result",
-       "errorRedirect": "http://localhost:22201/agent-registration/register/anti-money-laundering/evidence/error",
+       "successRedirect": "http://localhost:22201/agent-registration/apply/anti-money-laundering/evidence/upload-result",
+       "errorRedirect": "http://localhost:22201/agent-registration/apply/anti-money-laundering/evidence/error",
        "maximumFileSize": 5242880
    }
    """

--- a/test/uk/gov/hmrc/agentregistrationfrontend/views/register/aboutyourapplication/CheckYourAnswerPageSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/views/register/aboutyourapplication/CheckYourAnswerPageSpec.scala
@@ -76,12 +76,12 @@ extends ViewSpec:
           TestSummaryRow(
             key = "Business type",
             value = "Sole trader",
-            action = "/agent-registration/register/about-your-application/business-type"
+            action = "/agent-registration/apply/about-your-application/business-type"
           ),
           TestSummaryRow(
             key = "Are you the business owner?",
             value = "Yes",
-            action = "/agent-registration/register/about-your-application/user-role"
+            action = "/agent-registration/apply/about-your-application/user-role"
           )
         )
       )

--- a/test/uk/gov/hmrc/agentregistrationfrontend/views/register/aboutyourbusiness/AgentTypePageSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/views/register/aboutyourbusiness/AgentTypePageSpec.scala
@@ -45,8 +45,8 @@ extends ViewSpec:
       )
       doc.mainContent.extractRadioGroup() shouldBe expectedRadioGroup
 
-    "render a save and continue button" in:
-      doc.select("button[type=submit]").text() shouldBe "Save and continue"
+    "render a continue button" in:
+      doc.select("button[type=submit]").text() shouldBe "Continue"
 
     "render a form error when the form contains an error" in:
       val field = "agentType"

--- a/test/uk/gov/hmrc/agentregistrationfrontend/views/register/aboutyourbusiness/BusinessTypeSessionPageSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/views/register/aboutyourbusiness/BusinessTypeSessionPageSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.views.register.aboutyourbusiness
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import uk.gov.hmrc.agentregistrationfrontend.forms.BusinessTypeSessionForm
+import uk.gov.hmrc.agentregistrationfrontend.testsupport.ViewSpec
+import uk.gov.hmrc.agentregistrationfrontend.views.html.register.aboutyourbusiness.BusinessTypeSessionPage
+
+class BusinessTypeSessionPageSpec
+extends ViewSpec:
+
+  val viewTemplate: BusinessTypeSessionPage = app.injector.instanceOf[BusinessTypeSessionPage]
+  implicit val doc: Document = Jsoup.parse(viewTemplate(BusinessTypeSessionForm.form).body)
+  private val heading: String = "How is your business set up?"
+
+  "BusinessTypeSessionPage" should:
+
+    "have the correct title" in:
+      doc.title() shouldBe s"$heading - Apply for an agent services account - GOV.UK"
+
+    "render a radio button for each option" in:
+      val expectedRadioGroup: TestRadioGroup = TestRadioGroup(
+        legend = heading,
+        options = List(
+          "Sole trader" -> "SoleTrader",
+          "Limited company" -> "LimitedCompany",
+          "A type of partnership" -> "PartnershipType",
+          "Something else" -> "NotSupported"
+        ),
+        hint = None
+      )
+      doc.mainContent.extractRadioGroup() shouldBe expectedRadioGroup
+
+    "render a continue button" in:
+      doc.select("button[type=submit]").text() shouldBe "Continue"
+
+    "render a form error when the form contains an error" in:
+      val field = "businessType"
+      val errorMessage = "Tell us how your business is set up"
+      val formWithError = BusinessTypeSessionForm.form
+        .withError(field, errorMessage)
+      val errorDoc: Document = Jsoup.parse(viewTemplate(formWithError).body)
+      errorDoc.title() shouldBe s"Error: $heading - Apply for an agent services account - GOV.UK"
+      errorDoc.selectOrFail(".govuk-error-summary__title").selectOnlyOneElementOrFail().text() shouldBe "There is a problem"
+      errorDoc.selectOrFail(".govuk-error-summary__list > li > a").selectOnlyOneElementOrFail().selectAttrOrFail("href") shouldBe s"#$field"
+      errorDoc.selectOrFail(".govuk-error-message").selectOnlyOneElementOrFail().text() shouldBe s"Error: $errorMessage"

--- a/test/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/CheckYourAnswersPageSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/views/register/amls/CheckYourAnswersPageSpec.scala
@@ -100,12 +100,12 @@ extends ViewSpec:
           TestSummaryRow(
             key = "Supervisory body",
             value = "HM Revenue and Customs (HMRC)",
-            action = "/agent-registration/register/anti-money-laundering/supervisor-name"
+            action = "/agent-registration/apply/anti-money-laundering/supervisor-name"
           ),
           TestSummaryRow(
             key = "Registration number",
             value = "XAML00000123456",
-            action = "/agent-registration/register/anti-money-laundering/registration-number"
+            action = "/agent-registration/apply/anti-money-laundering/registration-number"
           )
         )
       )
@@ -152,22 +152,22 @@ extends ViewSpec:
           TestSummaryRow(
             key = "Supervisory body",
             value = "Financial Conduct Authority (FCA)",
-            action = "/agent-registration/register/anti-money-laundering/supervisor-name"
+            action = "/agent-registration/apply/anti-money-laundering/supervisor-name"
           ),
           TestSummaryRow(
             key = "Registration number",
             value = "1234567890",
-            action = "/agent-registration/register/anti-money-laundering/registration-number"
+            action = "/agent-registration/apply/anti-money-laundering/registration-number"
           ),
           TestSummaryRow(
             key = "Supervision expiry date",
             value = "2 September 2026",
-            action = "/agent-registration/register/anti-money-laundering/supervision-runs-out"
+            action = "/agent-registration/apply/anti-money-laundering/supervision-runs-out"
           ),
           TestSummaryRow(
             key = "Evidence of anti-money laundering supervision",
             value = "test.pdf",
-            action = "/agent-registration/register/anti-money-laundering/evidence"
+            action = "/agent-registration/apply/anti-money-laundering/evidence"
           )
         )
       )


### PR DESCRIPTION
Includes an update to testSupport/WSHelper to enable existing session cookies to persist when we are using test-only endpoints to stub session data for tests.

Also implements the update to the generic routes from `/register` to `/apply`