### PR TITLE
APB-9881, APB-9916: cleanup, `routes.Controller.url` methods for URLs instead of hardcoded strings

### DIFF
--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/AgentTypeController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourbusiness/AgentTypeController.scala
@@ -50,10 +50,7 @@ extends FrontendController(mcc):
     implicit request: Request[?] =>
       AgentTypeForm.form.bindFromRequest().fold(
         formWithErrors => BadRequest(view(formWithErrors)),
-        (agentType: AgentType) =>
-          if agentType == AgentType.UkTaxAgent
-          then
-            Redirect(routes.BusinessTypeSessionController.show.url)
-              .addAgentTypeToSession(agentType)
-          else Redirect(applicationRoutes.AgentApplicationController.genericExitPage.url)
+        _ match
+          case AgentType.UkTaxAgent => Redirect(routes.BusinessTypeSessionController.show.url)
+          case AgentType.NonUkTaxAgent => Redirect(applicationRoutes.AgentApplicationController.genericExitPage.url)
       )

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourapplication/CheckYourAnswerControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourapplication/CheckYourAnswerControllerSpec.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.agentregistrationfrontend.services.ApplicationFactory
 import uk.gov.hmrc.agentregistrationfrontend.testsupport.ControllerSpec
 import uk.gov.hmrc.agentregistrationfrontend.testsupport.wiremock.stubs.AgentRegistrationStubs
 import uk.gov.hmrc.agentregistrationfrontend.testsupport.wiremock.stubs.AuthStubs
+import uk.gov.hmrc.agentregistrationfrontend.controllers.routes as appRoutes
 
 class CheckYourAnswerControllerSpec
 extends ControllerSpec:
@@ -55,7 +56,7 @@ extends ControllerSpec:
     response.status shouldBe Status.OK
     response.parseBodyAsJsoupDocument.title() shouldBe "Check your answers - Apply for an agent services account - GOV.UK"
 
-  "POST /apply/about-your-application/check-answer with confirm and continue selection should redirect to the next page" in:
+  s"POST $path with confirm and continue selection should redirect to start Grs journey Url" in:
     AuthStubs.stubAuthorise()
     AgentRegistrationStubs.stubApplicationInProgress(fakeAgentApplication)
     AgentRegistrationStubs.stubUpdateAgentApplication
@@ -63,4 +64,4 @@ extends ControllerSpec:
     val response: WSResponse = post(path)(Map.empty)
 
     response.status shouldBe Status.SEE_OTHER
-    response.header("Location").value shouldBe "/agent-registration/apply/start-grs-journey"
+    response.header("Location").value shouldBe appRoutes.GrsController.startGrsJourney.url

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourapplication/UserRoleControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/aboutyourapplication/UserRoleControllerSpec.scala
@@ -61,7 +61,7 @@ extends ControllerSpec:
 
     response.status shouldBe Status.SEE_OTHER
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/apply/about-your-application/check-your-answers"
+    response.header("Location").value shouldBe routes.CheckYourAnswerController.show.url
 
   s"POST $path without valid selection should return 400" in:
     AuthStubs.stubAuthorise()

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsSupervisorControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/amls/AmlsSupervisorControllerSpec.scala
@@ -20,6 +20,7 @@ import play.api.libs.ws.DefaultBodyReadables.*
 import play.api.libs.ws.WSResponse
 import uk.gov.hmrc.agentregistration.shared.AgentApplication
 import uk.gov.hmrc.agentregistrationfrontend.services.ApplicationFactory
+import uk.gov.hmrc.agentregistrationfrontend.controllers.routes as appRoutes
 import uk.gov.hmrc.agentregistrationfrontend.testsupport.wiremock.stubs.AgentRegistrationStubs
 import uk.gov.hmrc.agentregistrationfrontend.testsupport.wiremock.stubs.AuthStubs
 import uk.gov.hmrc.agentregistrationfrontend.testsupport.ControllerSpec
@@ -60,7 +61,7 @@ extends ControllerSpec:
 
     response.status shouldBe 303
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/apply/anti-money-laundering/registration-number"
+    response.header("Location").value shouldBe routes.AmlsRegistrationNumberController.show.url
 
   s"POST $path with save for later and valid selection should redirect to the saved for later page" in:
     AuthStubs.stubAuthorise()
@@ -74,7 +75,7 @@ extends ControllerSpec:
 
     response.status shouldBe 303
     response.body[String] shouldBe ""
-    response.header("Location").value shouldBe "/agent-registration/apply/save-and-come-back-later"
+    response.header("Location").value shouldBe appRoutes.AgentApplicationController.saveAndComeBackLater.url
 
   s"POST $path without valid selection should return 400" in:
     AuthStubs.stubAuthorise()


### PR DESCRIPTION
Signed-off-by: paweldigital <173694350+paweldigital@users.noreply.github.com>
