### PR TITLE
APB-11018 Individual fixable failures outcome page

### DIFF
--- a/app/uk/gov/hmrc/agentregistrationfrontend/action/individual/IndividualActions.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/action/individual/IndividualActions.scala
@@ -20,11 +20,14 @@ import play.api.mvc.*
 import play.api.mvc.Results.NotFound
 import play.api.mvc.Results.Redirect
 import uk.gov.hmrc.agentregistration.shared.AgentApplication
+import uk.gov.hmrc.agentregistration.shared.BusinessPartnerRecordResponse
 import uk.gov.hmrc.agentregistration.shared.InternalUserId
 import uk.gov.hmrc.agentregistration.shared.LinkId
 import uk.gov.hmrc.agentregistration.shared.Nino
 import uk.gov.hmrc.agentregistration.shared.SaUtr
 import uk.gov.hmrc.agentregistration.shared.individual.IndividualProvidedDetails
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix._10.IndividualDetailsFix
 import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeApplication
 import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual
 import uk.gov.hmrc.agentregistration.shared.risking.RiskingProgress
@@ -34,9 +37,10 @@ import uk.gov.hmrc.agentregistrationfrontend.action.ActionBuildersWithData
 import uk.gov.hmrc.agentregistrationfrontend.action.RequestWithDataCt
 import uk.gov.hmrc.agentregistrationfrontend.config.AppConfig
 import uk.gov.hmrc.agentregistrationfrontend.controllers.AppRoutes
+import uk.gov.hmrc.agentregistrationfrontend.services.BusinessPartnerRecordService
 import uk.gov.hmrc.agentregistrationfrontend.services.applicant.AgentApplicationService
-import uk.gov.hmrc.agentregistrationfrontend.services.individual.IndividualRiskingService
 import uk.gov.hmrc.agentregistrationfrontend.services.individual.IndividualProvideDetailsService
+import uk.gov.hmrc.agentregistrationfrontend.services.individual.IndividualRiskingService
 import uk.gov.hmrc.agentregistrationfrontend.util.RequestAwareLogging
 import uk.gov.hmrc.auth.core.ConfidenceLevel
 import uk.gov.hmrc.auth.core.retrieve.Credentials
@@ -69,7 +73,9 @@ object IndividualActions:
 
   type DataWithRiskingProgress = RiskingProgress *: DataWithIndividualProvidedDetails
 
-  type DataWithRiskingOutcome = RiskingOutcomeIndividual *: RiskingOutcomeApplication *: DataWithIndividualProvidedDetails
+  type DataWithRiskingOutcome = BusinessPartnerRecordResponse *: RiskingOutcomeIndividual *: RiskingOutcomeApplication *: DataWithIndividualProvidedDetails
+  type DataWithIndividualDetailsFix =
+    IndividualDetailsFix *: BusinessPartnerRecordResponse *: RiskingOutcomeIndividual.FailedFixable *: RiskingOutcomeApplication *: DataWithIndividualProvidedDetails
 
 @Singleton
 class IndividualActions @Inject (
@@ -79,7 +85,8 @@ class IndividualActions @Inject (
   individualAuthorisedRefiner: IndividualAuthRefiner,
   agentApplicationService: AgentApplicationService,
   individualProvideDetailsService: IndividualProvideDetailsService,
-  individualRiskingService: IndividualRiskingService
+  individualRiskingService: IndividualRiskingService,
+  businessPartnerRecordService: BusinessPartnerRecordService
 )(using ExecutionContext)
 extends RequestAwareLogging:
 
@@ -172,11 +179,45 @@ extends RequestAwareLogging:
       val agentApplication: AgentApplication = request.get
       agentApplication.riskingOutcomeApplication match
         case Some(riskingOutcomeApplication) => request.add[RiskingOutcomeApplication](riskingOutcomeApplication)
-        case None => NotFound
+        case None =>
+          logger.info("Risking outcome for application not found.")
+          NotFound
     )
     .refine(implicit request =>
       val individualProvidedDetails: IndividualProvidedDetails = request.get
       individualProvidedDetails.riskingOutcomeIndividual match
         case Some(riskingOutcomeIndividual) => request.add[RiskingOutcomeIndividual](riskingOutcomeIndividual)
-        case None => NotFound
+        case None =>
+          logger.info("Risking outcome for individual not found.")
+          NotFound
     )
+    .refine:
+      implicit request =>
+        businessPartnerRecordService
+          .getApplicationBusinessPartnerRecord(request.agentApplication.getUtr)
+          .map:
+            case Some(bpr) => request.add[BusinessPartnerRecordResponse](bpr)
+            case _ => throw new IllegalStateException(s"Business Partner Record not found for application with UTR: ${request.agentApplication.getUtr}")
+
+  def authorisedWithFixableDetails(linkId: LinkId): ActionBuilderWithData[DataWithIndividualDetailsFix] = authorisedWithRiskingOutcome(linkId)
+    .refine:
+      implicit request: (RequestWithData[DataWithRiskingOutcome]) =>
+        val individualRiskingOutcome: RiskingOutcomeIndividual = request.get
+        individualRiskingOutcome match
+          case outcome @ RiskingOutcomeIndividual.FailedFixable(fixes: Seq[IndividualFix]) =>
+            fixes.collectFirst { case fix: IndividualDetailsFix => fix } match
+              case Some(individualFix) => request.add[IndividualDetailsFix](individualFix)
+              case None =>
+                logger.info("Risking outcome for individual does not require individual details to be provided.")
+                NotFound
+          case _ =>
+            logger.info("Risking outcome for individual is not fixable. Redirecting to where outcome can be handled.")
+            Redirect(AppRoutes.providedetails.riskingoutcome.RiskingOutcomeController.show(linkId))
+    .refine:
+      implicit request: (RequestWithData[IndividualDetailsFix *: DataWithRiskingOutcome]) =>
+        val riskingOutcomeIndividual: RiskingOutcomeIndividual = request.get
+        riskingOutcomeIndividual match
+          case outcome: RiskingOutcomeIndividual.FailedFixable => request.replace[RiskingOutcomeIndividual, RiskingOutcomeIndividual.FailedFixable](outcome)
+          case _ =>
+            logger.info("Risking outcome for individual is not fixable. Redirecting to where outcome can be handled.")
+            Redirect(AppRoutes.providedetails.riskingoutcome.RiskingOutcomeController.show(linkId))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/AppRoutes.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/AppRoutes.scala
@@ -37,6 +37,8 @@ import uk.gov.hmrc.agentregistrationfrontend.controllers.applicant.internal.rout
 import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.routes as providedetailsRoutes
 import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingprogress.routes as riskingProgressRoutes
 import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.routes as individualRiskingOutcomeRoutes
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.routes as individualFixableFailuresRoutes
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails.routes as fixProvidedDetailsRoutes
 import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.internal.routes as internalIndividualRoutes
 import uk.gov.hmrc.agentregistrationfrontend.testonly.controllers.routes as testOnlyRoutes
 import uk.gov.hmrc.agentregistrationfrontend.testonly.controllers.applicant.routes as testOnlyApplicantRoutes
@@ -175,6 +177,7 @@ object AppRoutes:
 
     val FixableTaskListController = fixableFailuresRoutes.FixableTaskListController
     val SaveForLaterController = fixableFailuresRoutes.SaveForLaterController
+    val DeclarationController = fixableFailuresRoutes.DeclarationController
 
     object amlsfailure:
 
@@ -210,7 +213,23 @@ object AppRoutes:
     val NotAgentCredentialController = providedetailsRoutes.NotAgentCredentialController
 
     object riskingoutcome:
+
       val RiskingOutcomeController = individualRiskingOutcomeRoutes.RiskingOutcomeController
+
+      object fixablefailures:
+
+        val FixableTaskListController = individualFixableFailuresRoutes.FixableTaskListController
+        val FixableIndividualFailureController = individualFixableFailuresRoutes.FixableIndividualFailureController
+        val FixIndividualProvidedDetailsController = individualFixableFailuresRoutes.FixIndividualProvidedDetailsController
+        val DeclarationController = individualFixableFailuresRoutes.DeclarationController
+        val IndividualConfirmationController = individualFixableFailuresRoutes.IndividualConfirmationController
+
+        object provideddetails:
+
+          val CheckYourAnswersController = fixProvidedDetailsRoutes.CheckYourAnswersController
+          val IndividualDateOfBirthController = fixProvidedDetailsRoutes.IndividualDateOfBirthController
+          val IndividualNinoController = fixProvidedDetailsRoutes.IndividualNinoController
+          val IndividualSaUtrController = fixProvidedDetailsRoutes.IndividualSaUtrController
 
     object internal:
       val UcrIndividualController = internalIndividualRoutes.UcrIndividualController

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/applicant/fixablefailures/DeclarationController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/applicant/fixablefailures/DeclarationController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.applicant.fixablefailures
+
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.agentregistrationfrontend.action.applicant.ApplicantActions
+import uk.gov.hmrc.agentregistrationfrontend.controllers.applicant.FrontendController
+import uk.gov.hmrc.agentregistrationfrontend.views.html.SimplePage
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DeclarationController @Inject() (
+  mcc: MessagesControllerComponents,
+  actions: ApplicantActions,
+  simplePage: SimplePage
+)
+extends FrontendController(mcc, actions):
+
+  def show: Action[AnyContent] = action:
+    implicit request =>
+      Ok(simplePage(
+        h1 = "Declaration placeholder",
+        bodyText = Some("This is a placeholder for the declaration page.")
+      ))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/RiskingOutcomeController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/RiskingOutcomeController.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutc
 import play.api.mvc.*
 import uk.gov.hmrc.agentregistration.shared.AgentApplication
 import uk.gov.hmrc.agentregistration.shared.AgentApplicationSoleTrader
+import uk.gov.hmrc.agentregistration.shared.BusinessPartnerRecordResponse
 import uk.gov.hmrc.agentregistration.shared.LinkId
 import uk.gov.hmrc.agentregistration.shared.individual.IndividualProvidedDetails
 import uk.gov.hmrc.agentregistration.shared.risking.RiskedIndividual
@@ -26,14 +27,13 @@ import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeApplication
 import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual
 import uk.gov.hmrc.agentregistrationfrontend.action.individual.IndividualActions
 import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.FrontendController
-import uk.gov.hmrc.agentregistrationfrontend.services.BusinessPartnerRecordService
-import uk.gov.hmrc.agentregistrationfrontend.views.html.SimplePage
+import uk.gov.hmrc.agentregistrationfrontend.util.DisplayDate.displayDateForLang
+import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.FailedFixablePage
 import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingprogress.FailedNonFixablePage
 import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingprogress.IndividualConfirmationPage
 
 import javax.inject.Inject
 import javax.inject.Singleton
-import scala.concurrent.Future
 
 @Singleton
 class RiskingOutcomeController @Inject() (
@@ -41,54 +41,53 @@ class RiskingOutcomeController @Inject() (
   mcc: MessagesControllerComponents,
   individualConfirmationPage: IndividualConfirmationPage,
   failedNonFixablePage: FailedNonFixablePage,
-  businessPartnerRecordService: BusinessPartnerRecordService,
-  simplePage: SimplePage
+  failedFixablePage: FailedFixablePage
 )
 extends FrontendController(mcc, actions):
 
-  def show(linkId: LinkId): Action[AnyContent] = actions.authorisedWithRiskingOutcome(linkId).async:
-    implicit request =>
-      val riskingOutcomeApplication: RiskingOutcomeApplication = request.get
-      val riskingOutcomeIndividual: RiskingOutcomeIndividual = request.get
-      riskingOutcomeApplication.outcome match
-        case RiskingOutcomeApplication.Outcome.FailedNonFixable =>
-          riskingOutcomeIndividual match
-            case failedNonFixable: RiskingOutcomeIndividual.FailedNonFixable =>
-              val riskedIndividual: RiskedIndividual = RiskedIndividual(
-                personReference = request.get[IndividualProvidedDetails].personReference,
-                individualName = request.get[IndividualProvidedDetails].individualName,
-                failures = failedNonFixable.failures
-              )
-              businessPartnerRecordService
-                .getApplicationBusinessPartnerRecord(request.agentApplication.getUtr)
-                .map: optBpr =>
-                  Ok(failedNonFixablePage(
-                    riskedIndividual = riskedIndividual,
-                    agentApplication = request.agentApplication,
-                    entityName = optBpr.map(_.getEntityName).getOrThrowExpectedDataMissing("BPR for application entity is missing")
-                  ))
-            case _ => renderConfirmationPage(request.agentApplication) // this individual has not failed non-fixable, so render the confirmation page
-        case RiskingOutcomeApplication.Outcome.FailedFixable =>
-          riskingOutcomeIndividual match
-            case _: RiskingOutcomeIndividual.FailedFixable =>
-              // TODO: implement fixable failures outcome page which will then link to the individual fixable task list page
-              Future.successful(Ok(simplePage(
-                h1 = "Fixable failures outcome page",
-                bodyText = Some("This page is a placeholder for the fixable failures outcome page.")
-              )))
-            case _ => renderConfirmationPage(request.agentApplication) // this individual has not failed fixable, so render the confirmation page
-        case _ => renderConfirmationPage(request.agentApplication) // any other outcome renders the confirmation page
+  def show(linkId: LinkId): Action[AnyContent] =
+    actions.authorisedWithRiskingOutcome(linkId):
+      implicit request =>
+        val riskingOutcomeApplication: RiskingOutcomeApplication = request.get
+        val riskingOutcomeIndividual: RiskingOutcomeIndividual = request.get
+        val entityName: String = request.get[BusinessPartnerRecordResponse].getEntityName
+        riskingOutcomeApplication.outcome match
+          case RiskingOutcomeApplication.Outcome.FailedNonFixable =>
+            riskingOutcomeIndividual match
+              case failedNonFixable: RiskingOutcomeIndividual.FailedNonFixable =>
+                val riskedIndividual: RiskedIndividual = RiskedIndividual(
+                  personReference = request.get[IndividualProvidedDetails].personReference,
+                  individualName = request.get[IndividualProvidedDetails].individualName,
+                  failures = failedNonFixable.failures
+                )
+                Ok(failedNonFixablePage(
+                  riskedIndividual = riskedIndividual,
+                  agentApplication = request.agentApplication,
+                  entityName = entityName
+                ))
+              case _ => renderConfirmationPage(request.agentApplication, entityName) // this individual has not failed non-fixable, so render the confirmation page
+          case RiskingOutcomeApplication.Outcome.FailedFixable =>
+            riskingOutcomeIndividual match
+              case _: RiskingOutcomeIndividual.FailedFixable =>
+                Ok(failedFixablePage(
+                  linkId = linkId,
+                  entityName = entityName,
+                  correctiveActionExpiryDate = displayDateForLang(riskingOutcomeApplication.correctiveActionExpiryDate),
+                  actualDecisionDate = displayDateForLang(Some(riskingOutcomeApplication.riskingCompletedDate))
+                ))
+              case _ => renderConfirmationPage(request.agentApplication, entityName) // this individual has not failed fixable, so render the confirmation page
+          case _ => renderConfirmationPage(request.agentApplication, entityName) // any other outcome renders the confirmation page
 
-  private def renderConfirmationPage(agentApplication: AgentApplication)(using RequestHeader) =
+  private def renderConfirmationPage(
+    agentApplication: AgentApplication,
+    entityName: String
+  )(using RequestHeader) =
     val applicantName = agentApplication.getApplicantContactDetails.applicantName
-    businessPartnerRecordService
-      .getApplicationBusinessPartnerRecord(agentApplication.getUtr)
-      .map: optBpr =>
-        Ok(individualConfirmationPage(
-          applicantName = applicantName.value,
-          entityName = optBpr.map(_.getEntityName).getOrThrowExpectedDataMissing("BPR for application entity is missing"),
-          isSoleTraderOwner = agentApplication.isSoleTraderOwner
-        ))
+    Ok(individualConfirmationPage(
+      applicantName = applicantName.value,
+      entityName = entityName,
+      isSoleTraderOwner = agentApplication.isSoleTraderOwner
+    ))
 
   extension (agentApplication: AgentApplication)
     def isSoleTraderOwner: Boolean =

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/DeclarationController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/DeclarationController.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures
+
+import play.api.mvc.*
+import uk.gov.hmrc.agentregistration.shared.LinkId
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual
+import uk.gov.hmrc.agentregistrationfrontend.action.individual.IndividualActions
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.FrontendController
+import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.fixablefailures.DeclarationPage
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DeclarationController @Inject() (
+  actions: IndividualActions,
+  mcc: MessagesControllerComponents,
+  view: DeclarationPage
+)
+extends FrontendController(mcc, actions):
+
+  private def baseAction(
+    linkId: LinkId
+  ): ActionBuilderWithData[DataWithRiskingOutcome] = authorisedWithRiskingOutcome(linkId)
+    .ensure(
+      condition =
+        implicit request =>
+          val individualRiskingOutcome: RiskingOutcomeIndividual = request.get
+          individualRiskingOutcome match
+            case outcome @ RiskingOutcomeIndividual.FailedFixable(fixes: Seq[IndividualFix]) => fixes.forall(_.isConfirmed.contains(true))
+            case _ => false,
+      resultWhenConditionNotMet =
+        implicit r =>
+          Redirect(AppRoutes.providedetails.riskingoutcome.RiskingOutcomeController.show(linkId))
+    )
+
+  def show(linkId: LinkId): Action[AnyContent] =
+    baseAction(linkId):
+      implicit request =>
+        Ok(view(
+          linkId = linkId
+        ))
+
+  def submit(linkId: LinkId): Action[AnyContent] =
+    baseAction(linkId):
+      implicit request =>
+        Redirect(AppRoutes.providedetails.riskingoutcome.fixablefailures.IndividualConfirmationController.show(linkId))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/FixIndividualProvidedDetailsController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/FixIndividualProvidedDetailsController.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures
+
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.agentregistration.shared.LinkId
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix._10.IndividualDetailsFix
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeApplication
+import uk.gov.hmrc.agentregistrationfrontend.action.individual.IndividualActions
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.FrontendController
+import uk.gov.hmrc.agentregistrationfrontend.util.DisplayDate.displayDateForLang
+import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.fixablefailures.FixIndividualProvidedDetailsPage
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FixIndividualProvidedDetailsController @Inject() (
+  mcc: MessagesControllerComponents,
+  actions: IndividualActions,
+  view: FixIndividualProvidedDetailsPage
+)
+extends FrontendController(mcc, actions):
+
+  def show(
+    linkId: LinkId
+  ): Action[AnyContent] =
+    authorisedWithFixableDetails(linkId):
+      implicit request =>
+        val overallOutcome: RiskingOutcomeApplication = request.get
+        Ok(view(
+          failureCode = request.get[IndividualDetailsFix].toString,
+          correctiveActionExpiryDate = displayDateForLang(overallOutcome.correctiveActionExpiryDate),
+          linkId = linkId
+        ))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/FixableIndividualFailureController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/FixableIndividualFailureController.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures
+
+import com.softwaremill.quicklens.each
+import com.softwaremill.quicklens.modify
+import play.api.data.Form
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.agentregistration.shared.BusinessPartnerRecordResponse
+import uk.gov.hmrc.agentregistration.shared.LinkId
+import uk.gov.hmrc.agentregistration.shared.individual.IndividualProvidedDetails
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeApplication
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual
+import uk.gov.hmrc.agentregistration.shared.util.SafeEquals.===
+import uk.gov.hmrc.agentregistrationfrontend.action.individual.IndividualActions
+import uk.gov.hmrc.agentregistrationfrontend.config.AppConfig
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.FrontendController
+import uk.gov.hmrc.agentregistrationfrontend.forms.applicant.fixablefailures.ConfirmFixForm
+import uk.gov.hmrc.agentregistrationfrontend.services.individual.IndividualProvideDetailsService
+import uk.gov.hmrc.agentregistrationfrontend.util.DisplayDate.displayDateForLang
+import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.fixablefailures.FixableIndividualFailurePage
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FixableIndividualFailureController @Inject (individualProvidedDetailsService: IndividualProvideDetailsService)(
+  mcc: MessagesControllerComponents,
+  actions: IndividualActions,
+  view: FixableIndividualFailurePage,
+  appConfig: AppConfig
+)
+extends FrontendController(mcc, actions):
+
+  def baseAction(
+    fixCode: String,
+    linkId: LinkId
+  ): ActionBuilderWithData[IndividualFix *: DataWithRiskingOutcome] = actions
+    .authorisedWithRiskingOutcome(linkId)
+    .behindFeatureFlag(appConfig.Features.fixableFailures)
+    .refine(implicit request =>
+      val individualRiskingOutcome: RiskingOutcomeIndividual = request.get
+      individualRiskingOutcome match
+        case RiskingOutcomeIndividual.FailedFixable(fixes: Seq[IndividualFix]) =>
+          fixes.find(_.toString === fixCode) match
+            case Some(individualFix) => request.add[IndividualFix](individualFix)
+            case None =>
+              logger.warn(s"Risking outcome for individual does not contain a fix with code $fixCode.")
+              NotFound
+        case _ =>
+          logger.warn("Risking outcome for individual is not fixable. Redirecting to where outcome can be handled.")
+          Redirect(AppRoutes.providedetails.riskingoutcome.RiskingOutcomeController.show(linkId))
+    )
+
+  def show(
+    fixCode: String,
+    linkId: LinkId
+  ): Action[AnyContent] =
+    baseAction(fixCode, linkId):
+      implicit request =>
+        val overallOutcome: RiskingOutcomeApplication = request.get
+        Ok(view(
+          entityName = request.get[BusinessPartnerRecordResponse].getEntityName,
+          failureCode = fixCode,
+          correctiveActionExpiryDate = displayDateForLang(overallOutcome.correctiveActionExpiryDate),
+          form = ConfirmFixForm.form(fixCode).fill:
+            request.get[IndividualFix].isConfirmed
+          ,
+          linkId = linkId
+        ))
+
+  def submit(
+    fixCode: String,
+    linkId: LinkId
+  ): Action[AnyContent] = baseAction(fixCode, linkId)
+    .ensureValidForm(
+      form = implicit request => ConfirmFixForm.form(fixCode),
+      resultToServeWhenFormHasErrors =
+        implicit request =>
+          (formWithErrors: Form[Boolean]) =>
+            view(
+              entityName = request.get[BusinessPartnerRecordResponse].getEntityName,
+              failureCode = fixCode,
+              correctiveActionExpiryDate = displayDateForLang(request.get[RiskingOutcomeApplication].correctiveActionExpiryDate),
+              form = formWithErrors,
+              linkId = linkId
+            )
+    )
+    .async:
+      implicit request =>
+        val individualProvidedDetails: IndividualProvidedDetails = request.get
+        val updatedFixes: Seq[IndividualFix] =
+          individualProvidedDetails.riskingOutcomeIndividual match
+            case Some(outcome: RiskingOutcomeIndividual.FailedFixable) =>
+              outcome.fixes.map:
+                case f: IndividualFix if f === request.get[IndividualFix] => f.modify(_.isConfirmed).setTo(Some(request.get[Boolean]))
+                case other => other
+            case _ => throw new IllegalStateException("Risking outcome for individual is not fixable. Cannot update fixes.")
+        individualProvidedDetailsService.upsert(
+          individualProvidedDetails
+            .modify(_.riskingOutcomeIndividual.each)
+            .using:
+              case f: RiskingOutcomeIndividual.FailedFixable => f.copy(fixes = updatedFixes)
+              case other => other
+        ).map: _ =>
+          Redirect(AppRoutes.providedetails.riskingoutcome.fixablefailures.FixableTaskListController.show(linkId))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/FixableTaskListController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/FixableTaskListController.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures
+
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.agentregistration.shared.BusinessPartnerRecordResponse
+import uk.gov.hmrc.agentregistration.shared.LinkId
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeApplication
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual
+import uk.gov.hmrc.agentregistrationfrontend.action.individual.IndividualActions
+import uk.gov.hmrc.agentregistrationfrontend.config.AppConfig
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.FrontendController
+import uk.gov.hmrc.agentregistrationfrontend.model.FixableIndividualTaskListStatus
+import uk.gov.hmrc.agentregistrationfrontend.model.TaskStatus
+import uk.gov.hmrc.agentregistrationfrontend.util.DisplayDate.displayDateForLang
+import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.fixablefailures.FixableTaskListPage
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FixableTaskListController @Inject() (
+  mcc: MessagesControllerComponents,
+  actions: IndividualActions,
+  taskListPage: FixableTaskListPage,
+  appConfig: AppConfig
+)
+extends FrontendController(mcc, actions):
+
+  def show(linkId: LinkId): Action[AnyContent] =
+    actions
+      .authorisedWithRiskingOutcome(linkId)
+      .behindFeatureFlag(appConfig.Features.fixableFailures):
+        implicit request =>
+          val overallOutcome: RiskingOutcomeApplication = request.get
+          val riskingOutcomeIndividual: RiskingOutcomeIndividual = request.get
+          Ok(taskListPage(
+            taskListStatus = fixableIndividualTaskListStatus(
+              riskingOutcomeIndividual = riskingOutcomeIndividual
+            ),
+            entityName = request.get[BusinessPartnerRecordResponse].getEntityName,
+            correctiveActionExpiryDate = displayDateForLang(overallOutcome.correctiveActionExpiryDate),
+            linkId = linkId
+          ))
+
+  private def fixableIndividualTaskListStatus(
+    riskingOutcomeIndividual: RiskingOutcomeIndividual
+  ): FixableIndividualTaskListStatus =
+    val fixes: Seq[IndividualFix] =
+      riskingOutcomeIndividual match
+        case f: RiskingOutcomeIndividual.FailedFixable => f.fixes
+        case _ => Seq.empty
+    val fixesComplete: Boolean = fixes.forall(_.isConfirmed.contains(true)) | fixes.isEmpty
+    val fixableTasks: Map[String, TaskStatus] =
+      fixes.map(fix =>
+        fix.toString -> TaskStatus(
+          canStart = true,
+          isComplete = fix.isConfirmed.contains(true)
+        )
+      ).toMap
+
+    FixableIndividualTaskListStatus(
+      fixableTasks = fixableTasks,
+      declaration = TaskStatus(
+        canStart = fixesComplete, // Declaration can be started only when all prior tasks are complete
+        isComplete = false // Declaration is never "complete" until submission
+      )
+    )

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/IndividualConfirmationController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/IndividualConfirmationController.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures
+
+import play.api.mvc.*
+import uk.gov.hmrc.agentregistration.shared.AgentApplication
+import uk.gov.hmrc.agentregistration.shared.LinkId
+import uk.gov.hmrc.agentregistration.shared.contactdetails.ApplicantName
+import uk.gov.hmrc.agentregistration.shared.individual.IndividualProvidedDetails
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual
+import uk.gov.hmrc.agentregistrationfrontend.action.individual.IndividualActions
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.FrontendController
+import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.fixablefailures.ConfirmationPage
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class IndividualConfirmationController @Inject() (
+  actions: IndividualActions,
+  mcc: MessagesControllerComponents,
+  individualConfirmationPage: ConfirmationPage
+)
+extends FrontendController(mcc, actions):
+
+  private def baseAction(
+    linkId: LinkId
+  ): ActionBuilderWithData[DataWithRiskingOutcome] = authorisedWithRiskingOutcome(linkId)
+    .ensure(
+      condition =
+        implicit request =>
+          val individualRiskingOutcome: RiskingOutcomeIndividual = request.get
+          individualRiskingOutcome match
+            case outcome @ RiskingOutcomeIndividual.FailedFixable(fixes: Seq[IndividualFix]) => fixes.forall(_.isConfirmed.contains(true))
+            case _ => false,
+      resultWhenConditionNotMet =
+        implicit r =>
+          Redirect(AppRoutes.providedetails.riskingoutcome.RiskingOutcomeController.show(linkId))
+    )
+
+  def show(linkId: LinkId): Action[AnyContent] =
+    baseAction(linkId):
+      implicit request =>
+        val agentApplication: AgentApplication = request.get
+        val applicantName: ApplicantName = agentApplication.getApplicantContactDetails.applicantName
+        Ok(individualConfirmationPage(
+          applicantName = applicantName.value,
+          individualEmailAddress = request.get[IndividualProvidedDetails].getEmailAddress.emailAddress
+        ))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/provideddetails/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/provideddetails/CheckYourAnswersController.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails
+
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import com.softwaremill.quicklens.modify
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.agentregistration.shared.LinkId
+import uk.gov.hmrc.agentregistration.shared.individual.IndividualProvidedDetails
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix._10.IndividualDetailsFix
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual
+import uk.gov.hmrc.agentregistrationfrontend.action.individual.IndividualActions
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.FrontendController
+import uk.gov.hmrc.agentregistrationfrontend.services.individual.IndividualProvideDetailsService
+import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.fixablefailures.provideddetails.CheckYourAnswersPage
+
+@Singleton
+class CheckYourAnswersController @Inject() (
+  mcc: MessagesControllerComponents,
+  actions: IndividualActions,
+  view: CheckYourAnswersPage,
+  individualProvideDetailsService: IndividualProvideDetailsService
+)
+extends FrontendController(mcc, actions):
+
+  private def baseAction(
+    linkId: LinkId
+  ): ActionBuilderWithData[DataWithIndividualDetailsFix] = authorisedWithFixableDetails(linkId)
+    .ensure(
+      _.get[IndividualProvidedDetails].individualDateOfBirth.nonEmpty,
+      implicit request =>
+        Redirect(AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.IndividualDateOfBirthController.show(linkId))
+    )
+    .ensure(
+      _.get[IndividualProvidedDetails].individualNino.nonEmpty,
+      implicit request =>
+        Redirect(AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.IndividualNinoController.show(linkId))
+    )
+    .ensure(
+      _.get[IndividualProvidedDetails].individualSaUtr.nonEmpty,
+      implicit request =>
+        Redirect(AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.IndividualSaUtrController.show(linkId))
+    )
+
+  def show(linkId: LinkId): Action[AnyContent] =
+    baseAction(linkId):
+      implicit request =>
+        Ok(view(
+          individualProvidedDetails = request.get[IndividualDetailsFix],
+          linkId = linkId
+        ))
+
+  def submit(linkId: LinkId): Action[AnyContent] = baseAction(linkId)
+    .async:
+      implicit request =>
+        val fixableIndividual: RiskingOutcomeIndividual.FailedFixable = request.get
+        val updatedIndividualDetailsFix: IndividualDetailsFix = request.get[IndividualDetailsFix]
+          .modify(_.isConfirmed)
+          .setTo(Some(true))
+        val updatedFixes: Seq[IndividualFix] = fixableIndividual.fixes
+          .map:
+            case _: IndividualDetailsFix => updatedIndividualDetailsFix
+            case otherFix => otherFix
+        val updatedRiskingOutcomeIndividual: RiskingOutcomeIndividual.FailedFixable = fixableIndividual
+          .modify(_.fixes)
+          .setTo(updatedFixes)
+        individualProvideDetailsService
+          .upsert(
+            request.get[IndividualProvidedDetails]
+              .modify(_.riskingOutcomeIndividual)
+              .setTo(Some(updatedRiskingOutcomeIndividual))
+          )
+          .map: _ =>
+            Redirect(AppRoutes.providedetails.riskingoutcome.fixablefailures.FixableTaskListController.show(linkId).url)

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/provideddetails/IndividualDateOfBirthController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/provideddetails/IndividualDateOfBirthController.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails
+
+import com.softwaremill.quicklens.modify
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.agentregistration.shared.LinkId
+import uk.gov.hmrc.agentregistration.shared.individual.IndividualProvidedDetails
+import uk.gov.hmrc.agentregistration.shared.individual.UserProvidedDateOfBirth
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix._10.IndividualDetailsFix
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual
+import uk.gov.hmrc.agentregistrationfrontend.action.individual.IndividualActions
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.FrontendController
+import uk.gov.hmrc.agentregistrationfrontend.forms.IndividualDateOfBirthForm
+import uk.gov.hmrc.agentregistrationfrontend.services.individual.IndividualProvideDetailsService
+import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.fixablefailures.provideddetails.IndividualDateOfBirthPage
+
+import java.time.Clock
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class IndividualDateOfBirthController @Inject() (
+  actions: IndividualActions,
+  mcc: MessagesControllerComponents,
+  view: IndividualDateOfBirthPage,
+  individualProvideDetailsService: IndividualProvideDetailsService
+)(using clock: Clock)
+extends FrontendController(mcc, actions):
+
+  def show(linkId: LinkId): Action[AnyContent] =
+    authorisedWithFixableDetails(linkId):
+      implicit request =>
+        Ok(view(
+          IndividualDateOfBirthForm.form
+            .fill:
+              request.get[IndividualDetailsFix]
+                .dateOfBirth
+          ,
+          linkId = linkId
+        ))
+
+  def submit(linkId: LinkId): Action[AnyContent] = authorisedWithFixableDetails(linkId)
+    .ensureValidForm[UserProvidedDateOfBirth](
+      IndividualDateOfBirthForm.form,
+      implicit r => view(_, linkId)
+    )
+    .async:
+      implicit request =>
+        val validFormData: UserProvidedDateOfBirth = request.get
+        val fixableIndividual: RiskingOutcomeIndividual.FailedFixable = request.get
+        val updatedIndividualDetailsFix: IndividualDetailsFix = request.get[IndividualDetailsFix]
+          .modify(_.dateOfBirth)
+          .setTo(Some(validFormData))
+        val updatedFixes: Seq[IndividualFix] = fixableIndividual.fixes
+          .map:
+            case _: IndividualDetailsFix => updatedIndividualDetailsFix
+            case otherFix => otherFix
+        val updatedRiskingOutcomeIndividual: RiskingOutcomeIndividual.FailedFixable = fixableIndividual
+          .modify(_.fixes)
+          .setTo(updatedFixes)
+        individualProvideDetailsService
+          .upsert(
+            request.get[IndividualProvidedDetails]
+              .modify(_.riskingOutcomeIndividual)
+              .setTo(Some(updatedRiskingOutcomeIndividual))
+          )
+          .map: _ =>
+            Redirect(AppRoutes.providedetails.CheckYourAnswersController.show(linkId).url)

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/provideddetails/IndividualNinoController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/provideddetails/IndividualNinoController.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails
+
+import com.softwaremill.quicklens.modify
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.agentregistration.shared.LinkId
+import uk.gov.hmrc.agentregistration.shared.individual.IndividualProvidedDetails
+import uk.gov.hmrc.agentregistration.shared.individual.UserProvidedNino
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix._10.IndividualDetailsFix
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual
+import uk.gov.hmrc.agentregistrationfrontend.action.individual.IndividualActions
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.FrontendController
+import uk.gov.hmrc.agentregistrationfrontend.forms.IndividualNinoForm
+import uk.gov.hmrc.agentregistrationfrontend.services.individual.IndividualProvideDetailsService
+import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.fixablefailures.provideddetails.IndividualNinoPage
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class IndividualNinoController @Inject() (
+  actions: IndividualActions,
+  mcc: MessagesControllerComponents,
+  view: IndividualNinoPage,
+  individualProvideDetailsService: IndividualProvideDetailsService
+)
+extends FrontendController(mcc, actions):
+
+  def show(linkId: LinkId): Action[AnyContent] =
+    authorisedWithFixableDetails(linkId):
+      implicit request =>
+        Ok(view(
+          form = IndividualNinoForm.form
+            .fill:
+              request
+                .get[IndividualDetailsFix]
+                .nino
+          ,
+          linkId = linkId
+        ))
+
+  def submit(linkId: LinkId): Action[AnyContent] = authorisedWithFixableDetails(linkId)
+    .ensureValidForm[UserProvidedNino](
+      IndividualNinoForm.form,
+      implicit r => view(_, linkId)
+    )
+    .async:
+      implicit request =>
+        val validFormData: UserProvidedNino = request.get
+        val fixableIndividual: RiskingOutcomeIndividual.FailedFixable = request.get
+        val updatedIndividualDetailsFix: IndividualDetailsFix = request.get[IndividualDetailsFix]
+          .modify(_.nino)
+          .setTo(Some(validFormData))
+        val updatedFixes: Seq[IndividualFix] = fixableIndividual.fixes
+          .map:
+            case _: IndividualDetailsFix => updatedIndividualDetailsFix
+            case otherFix => otherFix
+        val updatedRiskingOutcomeIndividual: RiskingOutcomeIndividual.FailedFixable = fixableIndividual
+          .modify(_.fixes)
+          .setTo(updatedFixes)
+        individualProvideDetailsService
+          .upsert(
+            request.get[IndividualProvidedDetails]
+              .modify(_.riskingOutcomeIndividual)
+              .setTo(Some(updatedRiskingOutcomeIndividual))
+          )
+          .map: _ =>
+            Redirect(AppRoutes.providedetails.CheckYourAnswersController.show(linkId).url)

--- a/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/provideddetails/IndividualSaUtrController.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/fixablefailures/provideddetails/IndividualSaUtrController.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails
+
+import com.softwaremill.quicklens.modify
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.agentregistration.shared.LinkId
+import uk.gov.hmrc.agentregistration.shared.individual.IndividualProvidedDetails
+import uk.gov.hmrc.agentregistration.shared.individual.UserProvidedSaUtr
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix._10.IndividualDetailsFix
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual
+import uk.gov.hmrc.agentregistrationfrontend.action.individual.IndividualActions
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.FrontendController
+import uk.gov.hmrc.agentregistrationfrontend.forms.IndividualSaUtrForm
+import uk.gov.hmrc.agentregistrationfrontend.services.individual.IndividualProvideDetailsService
+import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.fixablefailures.provideddetails.IndividualSaUtrPage
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class IndividualSaUtrController @Inject() (
+  actions: IndividualActions,
+  mcc: MessagesControllerComponents,
+  view: IndividualSaUtrPage,
+  individualProvideDetailsService: IndividualProvideDetailsService
+)
+extends FrontendController(mcc, actions):
+
+  def show(linkId: LinkId): Action[AnyContent] =
+    authorisedWithFixableDetails(linkId):
+      implicit request =>
+        Ok(view(
+          form = IndividualSaUtrForm.form
+            .fill:
+              request.get[IndividualDetailsFix]
+                .saUtr
+          ,
+          linkId = linkId
+        ))
+
+  def submit(linkId: LinkId): Action[AnyContent] = authorisedWithFixableDetails(linkId)
+    .ensureValidForm[UserProvidedSaUtr](
+      IndividualSaUtrForm.form,
+      implicit r => view(_, linkId)
+    )
+    .async:
+      implicit request: RequestWithData[UserProvidedSaUtr *: DataWithIndividualDetailsFix] =>
+        val validFormData: UserProvidedSaUtr = request.get
+        val fixableIndividual: RiskingOutcomeIndividual.FailedFixable = request.get
+        val updatedIndividualDetailsFix: IndividualDetailsFix = request.get[IndividualDetailsFix]
+          .modify(_.saUtr)
+          .setTo(Some(validFormData))
+        val updatedFixes: Seq[IndividualFix] = fixableIndividual.fixes
+          .map:
+            case _: IndividualDetailsFix => updatedIndividualDetailsFix
+            case otherFix => otherFix
+        val updatedRiskingOutcomeIndividual: RiskingOutcomeIndividual.FailedFixable = fixableIndividual
+          .modify(_.fixes)
+          .setTo(updatedFixes)
+        individualProvideDetailsService
+          .upsert(
+            request.get[IndividualProvidedDetails]
+              .modify(_.riskingOutcomeIndividual)
+              .setTo(Some(updatedRiskingOutcomeIndividual))
+          )
+          .map: _ =>
+            Redirect(AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.CheckYourAnswersController.show(linkId).url)

--- a/app/uk/gov/hmrc/agentregistrationfrontend/model/AgentApplicationExt.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/model/AgentApplicationExt.scala
@@ -20,7 +20,6 @@ import uk.gov.hmrc.agentregistration.shared.*
 import uk.gov.hmrc.agentregistration.shared.individual.IndividualProvidedDetails
 import uk.gov.hmrc.agentregistration.shared.individual.ProvidedDetailsState
 import uk.gov.hmrc.agentregistration.shared.lists.NumberOfIndividuals
-import uk.gov.hmrc.agentregistration.shared.risking.EntityFix
 import uk.gov.hmrc.agentregistration.shared.risking.EntityFix._3.AmlsFix
 import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeEntity
 import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual

--- a/app/uk/gov/hmrc/agentregistrationfrontend/model/TaskListStatus.scala
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/model/TaskListStatus.scala
@@ -34,6 +34,11 @@ final case class FixableTaskListStatus(
   declaration: TaskStatus
 )
 
+final case class FixableIndividualTaskListStatus(
+  fixableTasks: Map[String, TaskStatus] = Map.empty,
+  declaration: TaskStatus
+)
+
 final case class TaskStatus(
   canStart: Boolean,
   isComplete: Boolean

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/applicant/fixablefailures/FixableTaskListPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/applicant/fixablefailures/FixableTaskListPage.scala.html
@@ -137,7 +137,7 @@
                     content = Text(messages(s"$key.declaration.linkText"))
                 ),
                 status = if(taskListStatus.declaration.canStart) incomplete else cannotStart,
-                href = if(taskListStatus.declaration.canStart) Some(AppRoutes.apply.DeclarationController.show.url) else None
+                href = if(taskListStatus.declaration.canStart) Some(AppRoutes.fixablefailures.DeclarationController.show.url) else None
             )
         ),
         idPrefix = "declaration"

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/applicant/fixablefailures/individualfailures/FixableIndividualsPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/applicant/fixablefailures/individualfailures/FixableIndividualsPage.scala.html
@@ -139,7 +139,7 @@
 
   <p class="govuk-body">
     @continueOrSaveForLaterLinks(
-      continueHref = AppRoutes.apply.TaskListController.show.url,
+      continueHref = AppRoutes.fixablefailures.FixableTaskListController.show.url,
       continueLabel = Some(messages("common.returnToTaskList"))
     )
   </p>

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/FailedFixablePage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/FailedFixablePage.scala.html
@@ -1,0 +1,76 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentregistration.shared.LinkId
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
+@import uk.gov.hmrc.agentregistrationfrontend.config.AppConfig
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        appConfig: AppConfig
+)
+
+@(
+        linkId: LinkId,
+        entityName: String,
+        correctiveActionExpiryDate: String,
+        actualDecisionDate: String
+)(implicit
+        request: RequestHeader,
+        messages: Messages
+)
+
+@key = @{"individualFailedFixable"}
+@pageTitle = @{messages(s"$key.title")}
+
+@layout(pageTitle = pageTitle, suppressBackLink = true) {
+  <h2 class="govuk-caption-l">@messages(s"$key.caption")</h2>
+  <h1 class="govuk-heading-l">@pageTitle</h1>
+  <h2 class="govuk-heading-m">@messages(s"$key.decisionDate.h2", actualDecisionDate)</h2>
+  <h2 class="govuk-heading-m">@messages(s"$key.ourDecision.h2")</h2>
+  <p class="govuk-body">@{messages(s"$key.ourDecision.p1", entityName)}</p>
+  <p class="govuk-body">@{Html(messages(s"$key.ourDecision.p2", appConfig.govukFinanceAct2026Url))}</p>
+  <p class="govuk-body">@{messages(s"$key.ourDecision.p3")}</p>
+  <p class="govuk-body">@{Html(messages(s"$key.ourDecision.p4", correctiveActionExpiryDate))}</p>
+  <h2 class="govuk-heading-m">@messages(s"$key.howToFix.h2")</h2>
+  <p class="govuk-body">@messages(s"$key.howToFix.p1")</p>
+    <p class="govuk-body">
+        @govukButton(Button(
+            content = Text(messages(s"$key.startButton")),
+            href= Some(
+              AppRoutes
+                .providedetails
+                .riskingoutcome
+                .fixablefailures
+                .FixableTaskListController
+                .show(linkId)
+                .url
+            ),
+            isStartButton = true
+        ))
+    </p>
+  <h2 class="govuk-heading-m">@messages(s"$key.failures.h2")</h2>
+  <p class="govuk-body">@messages(s"$key.failures.p1")</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>@messages(s"$key.failures.li1", entityName)</li>
+    <li>@Html(messages(s"$key.failures.li2", correctiveActionExpiryDate))</li>
+  </ul>
+  <h2 class="govuk-heading-m">@messages(s"$key.appeal.h2", entityName)</h2>
+  <p class="govuk-body">@messages(s"$key.appeal.p1")</p>
+  <p class="govuk-body">@Html(messages(s"$key.appeal.p2", appConfig.guidanceForFailedApplicationAppealsUrl))</p>
+  <p class="govuk-body">@messages(s"$key.appeal.p3")</p>
+}

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/ConfirmationPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/ConfirmationPage.scala.html
@@ -1,0 +1,73 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentregistrationfrontend.config.AppConfig
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
+@import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
+@import uk.gov.hmrc.agentregistration.shared.EmailAddress
+
+@this(
+        appConfig: AppConfig,
+        layout: Layout,
+        govukPanel: GovukPanel
+)
+
+@(
+        applicantName: String,
+        individualEmailAddress: EmailAddress)(implicit
+        request: RequestHeader,
+        messages: Messages
+)
+
+@key = @{
+    "individualDetailsFixConfirmation"
+}
+@pageTitle = @{messages(s"$key.title")}
+@signOutLink = @{
+  s"${appConfig.basFrontendSignOutUrlBase}?continueUrl=/feedback/AGENT_REG_IND_DETAILS"
+}
+
+@layout(
+    pageTitle = pageTitle,
+    suppressBackLink = true
+) {
+
+    @govukPanel(Panel(
+        title = Text(pageTitle)
+    ))
+
+    <h2 class="govuk-heading-m">
+    @{
+        messages(s"$key.h2")
+    }
+    </h2>
+    <p class="govuk-body">
+    @{
+      messages(s"$key.p1", applicantName)
+    }
+    </p>
+    <p class="govuk-body">
+    @{
+        messages(s"$key.p2", individualEmailAddress.value)
+    }
+    </p>
+
+    <p class="govuk-body govuk-!-display-none-print">
+        <a class="govuk-link" href=@signOutLink>@{
+          messages("common.finishAndSignOut")
+        }</a>
+    </p>
+}

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/DeclarationPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/DeclarationPage.scala.html
@@ -1,0 +1,49 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentregistration.shared.LinkId
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        formWithCSRF: FormWithCSRF
+)
+
+@(
+        linkId: LinkId
+)(implicit
+        request: RequestHeader,
+        messages: Messages
+)
+
+@key = @{"individualDetailsDeclaration"}
+@pageTitle = @{messages(s"$key.title")}
+
+@layout(pageTitle = pageTitle) {
+  <h2 class="govuk-caption-l">@messages(s"$key.caption")</h2>
+  <h1 class="govuk-heading-l">@pageTitle</h1>
+    <p class="govuk-body">
+        @{messages(s"$key.p1")}
+    </p>
+  @formWithCSRF(action = AppRoutes.providedetails.riskingoutcome.fixablefailures.DeclarationController.submit(linkId)) {
+    <p class="govuk-body">
+    @govukButton(Button(
+      content = Text(messages("declaration.accept.button"))
+    ))
+    </p>
+  }
+}

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/FixIndividualProvidedDetailsPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/FixIndividualProvidedDetailsPage.scala.html
@@ -1,0 +1,51 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentregistration.shared.LinkId
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
+@import uk.gov.hmrc.agentregistrationfrontend.forms.YesNo
+@import uk.gov.hmrc.govukfrontend.views.html.components.implicits.RichRadios
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton
+)
+
+@(
+        failureCode: String,
+        correctiveActionExpiryDate: String,
+        linkId: LinkId)(implicit
+        request: RequestHeader,
+        messages: Messages
+)
+
+@key = @{"fixableIndividualDetails"}
+@pageTitle = @{messages(s"$key.$failureCode.heading")}
+@layout(pageTitle = pageTitle) {
+  <h2 class="govuk-caption-l">@messages(s"$key.$failureCode.caption")</h2>
+  <h1 class="govuk-heading-l">@pageTitle</h1>
+  <p class="govuk-body">@messages(s"$key.$failureCode.p1")</p>
+  <p class="govuk-body">@messages(s"$key.$failureCode.p2")</p>
+  <p class="govuk-body">@messages(s"$key.$failureCode.p3")</p>
+  <p class="govuk-body">@Html(messages(s"$key.$failureCode.p4", correctiveActionExpiryDate))</p>
+  <p class="govuk-body">
+    @govukButton(Button(
+      href = Some(AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.CheckYourAnswersController.show(linkId).url),
+      content = Text(messages("common.continue"))
+    ))
+  </p>
+
+}

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/FixableIndividualFailurePage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/FixableIndividualFailurePage.scala.html
@@ -39,7 +39,7 @@
 @key = @{"fixableIndividualDetails"}
 @pageTitle = @{messages(s"$key.$failureCode.heading", entityName)}
 @layout(pageTitle = pageTitle, maybeForm = Some(form)) {
-  <h2 class="govuk-caption-l">@messages(s"$key.title")</h2>
+  <h2 class="govuk-caption-l">@messages(s"$key.$failureCode.caption")</h2>
   <h1 class="govuk-heading-l">@pageTitle</h1>
   <p class="govuk-body">@messages(s"$key.$failureCode.p1", entityName)</p>
   <p class="govuk-body">@messages(s"$key.$failureCode.p2", entityName)</p>

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/FixableIndividualFailurePage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/FixableIndividualFailurePage.scala.html
@@ -1,0 +1,85 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentregistration.shared.LinkId
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
+@import uk.gov.hmrc.agentregistrationfrontend.forms.YesNo
+@import uk.gov.hmrc.govukfrontend.views.html.components.implicits.RichRadios
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        formWithCSRF: FormWithCSRF,
+        govukRadios: GovukRadios
+)
+
+@(
+        entityName: String,
+        failureCode: String,
+        correctiveActionExpiryDate: String,
+        form: Form[Boolean],
+        linkId: LinkId)(implicit
+        request: RequestHeader,
+        messages: Messages
+)
+
+@key = @{"fixableIndividualDetails"}
+@pageTitle = @{messages(s"$key.$failureCode.heading", entityName)}
+@layout(pageTitle = pageTitle, maybeForm = Some(form)) {
+  <h2 class="govuk-caption-l">@messages(s"$key.title")</h2>
+  <h1 class="govuk-heading-l">@pageTitle</h1>
+  <p class="govuk-body">@messages(s"$key.$failureCode.p1", entityName)</p>
+  <p class="govuk-body">@messages(s"$key.$failureCode.p2", entityName)</p>
+  <h2 class="govuk-heading-m">@messages(s"$key.$failureCode.action.h2")</h2>
+  <p class="govuk-body">@messages(s"$key.$failureCode.action.p1", entityName)</p>
+  <p class="govuk-body">@Html(messages(s"$key.$failureCode.action.p2", correctiveActionExpiryDate))</p>
+  <p class="govuk-body">@messages(s"$key.$failureCode.action.p3")</p>
+  <p class="govuk-body">@Html(messages(s"$key.$failureCode.action.p4"))</p>
+
+  @formWithCSRF(AppRoutes.providedetails.riskingoutcome.fixablefailures.FixableIndividualFailureController.submit(failureCode, linkId)) {
+    @govukRadios(
+      Radios(
+        fieldset = Some(
+          Fieldset(
+            legend = Some(
+              Legend(
+                content = Text(messages(s"$key.$failureCode.label")),
+                isPageHeading = false,
+                classes = "govuk-fieldset__legend--m"
+              )
+            )
+          )
+        ),
+        items = Seq(
+          RadioItem(
+            content = Text(messages("common.yes")),
+            value = Some(YesNo.Yes.toString)
+          ),
+          RadioItem(
+            content = Text(messages("common.no")),
+            value = Some(YesNo.No.toString)
+          )
+        )
+      ).withFormField(form("isFixed"))
+    )
+    <p class="govuk-body">
+      @govukButton(Button(
+        content = Text(messages("common.saveAndContinue"))
+      ))
+    </p>
+  }
+
+}

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/FixableTaskListPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/FixableTaskListPage.scala.html
@@ -1,0 +1,94 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentregistrationfrontend.model.FixableIndividualTaskListStatus
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
+@import uk.gov.hmrc.agentregistration.shared.LinkId
+
+@this(
+        layout: Layout,
+        govukTaskList: GovukTaskList,
+        govukWarningText : GovukWarningText,
+        govukButton: GovukButton
+)
+
+@(
+        taskListStatus: FixableIndividualTaskListStatus,
+        entityName: String,
+        correctiveActionExpiryDate: String,
+        linkId: LinkId
+)(implicit
+        request: RequestHeader,
+        messages: Messages
+)
+
+@key = @{"fixableIndividualTaskList"}
+@title = @{messages(s"$key.title", entityName)}
+@incomplete = @{
+    TaskListItemStatus(
+        tag = Some(Tag(
+            content = Text(messages("taskList.status.Incomplete")),
+            classes = "govuk-tag--blue"
+        ))
+    )
+}
+@complete = @{
+    TaskListItemStatus(content = Text(messages("taskList.status.Completed")))
+}
+@cannotStart = @{
+    TaskListItemStatus(content = Text(messages("taskList.status.CannotStartYet")))
+}
+
+@layout(
+    pageTitle = title,
+    suppressBackLink = true
+) {
+
+    <h1 class="govuk-heading-l">@title</h1>
+    @govukWarningText(WarningText(
+      iconFallbackText = Some(messages("common.warning")),
+      content = Text(messages(s"$key.warning", correctiveActionExpiryDate))
+    ))
+
+    @if(taskListStatus.fixableTasks.nonEmpty) {
+        @govukTaskList(TaskList(
+            items = taskListStatus.fixableTasks.toSeq.map { case (k, v) =>
+              TaskListItem(
+                title = TaskListItemTitle(
+                  content = Text(messages(s"$key.$k.linkText"))
+                ),
+                status = if(v.isComplete) complete else incomplete,
+                href = Some(
+                  if k.startsWith("IndividualFix.10.")
+                  then
+                    AppRoutes.providedetails.riskingoutcome.fixablefailures.FixIndividualProvidedDetailsController.show(linkId).url
+                  else
+                    AppRoutes.providedetails.riskingoutcome.fixablefailures.FixableIndividualFailureController.show(k, linkId).url)
+              )
+            } ++ Seq(
+              TaskListItem(
+                title = TaskListItemTitle(
+                  content = Text(messages(s"$key.declaration.linkText"))
+                ),
+                status = if(taskListStatus.declaration.canStart) incomplete else cannotStart,
+                href = if(taskListStatus.declaration.canStart) Some(AppRoutes.providedetails.riskingoutcome.fixablefailures.DeclarationController.show(linkId).url) else None
+              )
+            ),
+            idPrefix = "fixableTasks"
+        ))
+    }
+
+}

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/provideddetails/AnswerSummary.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/provideddetails/AnswerSummary.scala.html
@@ -1,0 +1,119 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentregistration.shared.LinkId
+@import uk.gov.hmrc.agentregistration.shared.individual.IndividualDateOfBirth
+@import uk.gov.hmrc.agentregistration.shared.individual.IndividualNino
+@import uk.gov.hmrc.agentregistration.shared.individual.IndividualSaUtr
+@import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix._10.IndividualDetailsFix
+@import uk.gov.hmrc.agentregistrationfrontend.util.DisplayDate.displayDateForLang
+
+@import java.time.LocalDate
+
+@this(
+        govukSummaryList: GovukSummaryList
+)
+
+@(
+        key: String,
+        individualProvidedDetails: IndividualDetailsFix,
+        linkId: LinkId)(implicit
+        request: RequestHeader,
+        messages: Messages
+)
+
+@makeSummaryListRow(labelKey: String, valueText: String, changeHref: String) = @{
+    SummaryListRow(
+        key = Key(content = Text(messages(labelKey))),
+        value = Value(content = Text(valueText)),
+        actions = Some(
+            Actions(
+                items = Seq(
+                    ActionItem(
+                        href = changeHref,
+                        content = Text(messages("common.change")),
+                        visuallyHiddenText = Some(messages(labelKey))
+                    )
+                )
+            )
+        )
+    )
+}
+
+@dateOfBirthRow(dob: LocalDate) = @{
+    makeSummaryListRow(
+        labelKey = s"$key.dateOfBirth.label",
+        valueText = displayDateForLang(Some(dob)),
+        changeHref = AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.IndividualDateOfBirthController.show(linkId).toString
+    )
+}
+
+@hasNinoRow(hasNino: String) = @{
+    makeSummaryListRow(
+        labelKey = s"$key.hasNino.label",
+        valueText = hasNino,
+        changeHref = AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.IndividualNinoController.show(linkId).toString
+    )
+}
+
+@ninoRow(ninoText: String) = @{
+    makeSummaryListRow(
+        labelKey = s"$key.nino.label",
+        valueText = ninoText,
+        changeHref = AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.IndividualNinoController.show(linkId).toString
+    )
+}
+
+@hasSaUtrRow(hasSaUtr: String) = @{
+    makeSummaryListRow(
+        labelKey = s"$key.hasSaUtr.label",
+        valueText = hasSaUtr,
+        changeHref = AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.IndividualSaUtrController.show(linkId).toString
+    )
+}
+
+@saUtrRow(saUtrText: String) = @{
+    makeSummaryListRow(
+        labelKey = s"$key.saUtr.label",
+        valueText = saUtrText,
+        changeHref = AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.IndividualSaUtrController.show(linkId).toString
+    )
+}
+
+@rows = @{
+    val base = Seq.empty[SummaryListRow]
+
+  val dateOfBirthRows = individualProvidedDetails.dateOfBirth match {
+        case Some(IndividualDateOfBirth.Provided(dob)) => Seq(dateOfBirthRow(dob))
+        case _ => Seq.empty[SummaryListRow]
+    }
+
+    val ninoRows = individualProvidedDetails.nino match {
+        case Some(IndividualNino.Provided(nino)) => Seq(hasNinoRow("Yes"), ninoRow(nino.value))
+        case Some(IndividualNino.NotProvided) => Seq(hasNinoRow("No"))
+        case None => Seq.empty[SummaryListRow]
+    }
+
+    val saUtrRows = individualProvidedDetails.saUtr match {
+        case Some(IndividualSaUtr.Provided(saUtr)) => Seq(hasSaUtrRow("Yes"), saUtrRow(saUtr.value))
+        case Some(IndividualSaUtr.NotProvided) => Seq(hasSaUtrRow("No"))
+        case None => Seq.empty[SummaryListRow]
+    }
+
+    dateOfBirthRows ++ ninoRows ++ saUtrRows
+}
+
+@govukSummaryList(SummaryList(rows = rows))

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/provideddetails/CheckYourAnswersPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/provideddetails/CheckYourAnswersPage.scala.html
@@ -1,0 +1,60 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentregistration.shared.LinkId
+@import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix._10.IndividualDetailsFix
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.fixablefailures.provideddetails.AnswerSummary
+@import uk.gov.hmrc.govukfrontend.views.html.components.*
+
+@this(
+        layout: Layout,
+        govukButton: GovukButton,
+        answerSummary: AnswerSummary,
+        formWithCSRF: FormWithCSRF
+)
+
+@(
+        individualProvidedDetails: IndividualDetailsFix,
+        linkId: LinkId)(implicit
+        request: RequestHeader,
+        messages: Messages
+)
+
+@key = @{
+    "individualDetailsCheckYourAnswers"
+}
+@title = @{
+    messages(s"$key.title")
+}
+
+@layout(pageTitle = title) {
+  <h2 class="govuk-caption-l">@messages("relevant-individual.caption")</h2>
+    <h1 class="govuk-heading-l">@messages(s"$key.title")</h1>
+    @answerSummary(
+      key,
+      individualProvidedDetails = individualProvidedDetails,
+      linkId = linkId
+    )
+  @formWithCSRF(action = AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.CheckYourAnswersController.submit(linkId)) {
+    <p class="govuk-body">
+    @govukButton(Button(
+      content = Text(messages("common.confirmAndContinue"))
+    ))
+    </p>
+  }
+
+}

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/provideddetails/IndividualDateOfBirthPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/provideddetails/IndividualDateOfBirthPage.scala.html
@@ -1,0 +1,62 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentregistration.shared.individual.UserProvidedDateOfBirth
+@import uk.gov.hmrc.agentregistration.shared.LinkId
+@import uk.gov.hmrc.agentregistrationfrontend.forms.IndividualDateOfBirthForm
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.partials.SaveAndContinue
+@import uk.gov.hmrc.hmrcfrontend.views.html.components.implicits.*
+
+@this(
+        layout: Layout,
+        formWithCSRF: FormWithCSRF,
+        govukDateInput: GovukDateInput,
+        saveAndContinue: SaveAndContinue
+)
+
+@(
+        form: Form[UserProvidedDateOfBirth],
+        linkId: LinkId)(implicit
+        request: RequestHeader,
+        messages: Messages
+)
+
+@key = @{IndividualDateOfBirthForm.key}
+@pageTitle = @{messages(s"$key.title")}
+    
+@layout(
+    pageTitle = pageTitle,
+    maybeForm = Some(form)
+) {
+
+  <h2 class="govuk-caption-l">@messages("relevant-individual.caption")</h2>
+    @formWithCSRF(action = AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.IndividualDateOfBirthController.submit(linkId)) {
+        @govukDateInput(DateInput(
+            id = key,
+            hint = Some(Hint(content = Text(messages(s"$key.hint")))),
+            fieldset = Some(Fieldset(
+                legend = Some(Legend(
+                    content = Text(pageTitle),
+                    classes = "govuk-fieldset__legend--l",
+                    isPageHeading = true
+                ))
+            ))
+        ).withDayMonthYearFormField(form(key)))
+
+        @saveAndContinue()
+    }
+}

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/provideddetails/IndividualNinoPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/provideddetails/IndividualNinoPage.scala.html
@@ -1,0 +1,89 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentregistration.shared.LinkId
+@import uk.gov.hmrc.agentregistration.shared.individual.UserProvidedNino
+@import uk.gov.hmrc.agentregistrationfrontend.forms.IndividualNinoForm
+@import uk.gov.hmrc.agentregistrationfrontend.forms.YesNo
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.partials.SaveAndContinue
+@import uk.gov.hmrc.govukfrontend.views.html.components.implicits.RichRadios
+@import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
+
+@this(
+        layout: Layout,
+        govukRadios: GovukRadios,
+        govukInput: GovukInput,
+        formWithCSRF: FormWithCSRF,
+        govukButton: GovukButton,
+        saveAndContinue: SaveAndContinue
+)
+
+@(
+        form: Form[UserProvidedNino],
+        linkId: LinkId)(implicit
+        request: RequestHeader,
+        messages: Messages
+)
+
+@key = @{
+    IndividualNinoForm.hasNinoKey
+}
+@ninoKey = @{
+    IndividualNinoForm.ninoKey
+}
+@title = @{messages(s"$key.title")}
+
+@ninoInput = {
+    @govukInput(Input(
+        label = Label(
+            content = Text(messages(s"$ninoKey.label"))
+        ),
+        hint = Some(Hint(
+            content = Text(messages(s"$ninoKey.hint"))
+        )),
+        spellcheck = Some(false)
+    ).withFormField(form(ninoKey)))
+}
+@layout(
+    pageTitle = title,
+    maybeForm = Some(form)
+) {
+  <h2 class="govuk-caption-l">@messages("relevant-individual.caption")</h2>
+    @formWithCSRF(action = AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.IndividualNinoController.submit(linkId)) {
+        @govukRadios(Radios(
+            fieldset = Some(Fieldset(
+                legend = Some(Legend(
+                    content = Text(title),
+                    isPageHeading = true,
+                    classes = "govuk-fieldset__legend--l"
+                ))
+            )),
+            items = YesNo.values.toSeq.map:
+                case YesNo.Yes => RadioItem(
+                    content = HtmlContent(messages(s"$key.yes")),
+                    value = Some(YesNo.Yes.toString),
+                    conditionalHtml = Some(ninoInput)
+                )
+                case YesNo.No => RadioItem(
+                    content = HtmlContent(messages(s"$key.no")),
+                    value = Some(YesNo.No.toString)
+                )
+        ).withFormField(form(key)))
+
+        @saveAndContinue()
+    }
+}

--- a/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/provideddetails/IndividualSaUtrPage.scala.html
+++ b/app/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/fixablefailures/provideddetails/IndividualSaUtrPage.scala.html
@@ -1,0 +1,89 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentregistration.shared.LinkId
+@import uk.gov.hmrc.agentregistration.shared.individual.UserProvidedSaUtr
+@import uk.gov.hmrc.agentregistrationfrontend.forms.IndividualSaUtrForm
+@import uk.gov.hmrc.agentregistrationfrontend.forms.YesNo
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.Layout
+@import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.partials.SaveAndContinue
+@import uk.gov.hmrc.govukfrontend.views.html.components.implicits.RichRadios
+@import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
+
+@this(
+        layout: Layout,
+        govukRadios: GovukRadios,
+        govukInput: GovukInput,
+        formWithCSRF: FormWithCSRF,
+        govukButton: GovukButton,
+        saveAndContinue: SaveAndContinue
+)
+
+@(
+        form: Form[UserProvidedSaUtr],
+        linkId: LinkId)(implicit
+        request: RequestHeader,
+        messages: Messages
+)
+
+@key = @{
+    IndividualSaUtrForm.hasSaUtrKey
+}
+@saUtrKey = @{
+    IndividualSaUtrForm.saUtrKey
+}
+@title = @{messages(s"$key.title")}
+
+@saUtrInput = {
+    @govukInput(Input(
+        label = Label(
+            content = Text(messages(s"$saUtrKey.label"))
+        ),
+        hint = Some(Hint(
+            content = Text(messages(s"$saUtrKey.hint"))
+        )),
+        spellcheck = Some(false)
+    ).withFormField(form(saUtrKey)))
+}
+@layout(
+    pageTitle = title,
+    maybeForm = Some(form)
+) {
+  <h2 class="govuk-caption-l">@messages("relevant-individual.caption")</h2>
+    @formWithCSRF(action = AppRoutes.providedetails.riskingoutcome.fixablefailures.provideddetails.IndividualSaUtrController.submit(linkId)) {
+        @govukRadios(Radios(
+            fieldset = Some(Fieldset(
+                legend = Some(Legend(
+                    content = Text(title),
+                    isPageHeading = true,
+                    classes = "govuk-fieldset__legend--l"
+                ))
+            )),
+            items = YesNo.values.toSeq.map:
+                case YesNo.Yes => RadioItem(
+                    content = HtmlContent(messages(s"$key.yes")),
+                    value = Some(YesNo.Yes.toString),
+                    conditionalHtml = Some(saUtrInput)
+                )
+                case YesNo.No => RadioItem(
+                    content = HtmlContent(messages(s"$key.no")),
+                    value = Some(YesNo.No.toString)
+                )
+        ).withFormField(form(key)))
+
+        @saveAndContinue()
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -204,8 +204,22 @@ POST        /provide-details/individual-name-search/:linkId                 uk.g
 GET         /provide-details/contact-applicant                              uk.gov.hmrc.agentregistrationfrontend.controllers.individual.ContactApplicantController.show
 
 ## Risking outcome for individuals
-GET         /provide-details/outcome/:linkId                           uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.RiskingOutcomeController.show(linkId: LinkId)
-
+GET         /provide-details/outcome-status/:linkId                           uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.RiskingOutcomeController.show(linkId: LinkId)
+GET         /provide-details/conditions-not-yet-met/task-list/:linkId                 uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.FixableTaskListController.show(linkId: LinkId)
+GET         /provide-details/conditions-not-yet-met/failure-details/:fixCode/:linkId                 uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.FixableIndividualFailureController.show(fixCode: String, linkId: LinkId)
+POST        /provide-details/conditions-not-yet-met/failure-details/:fixCode/:linkId                 uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.FixableIndividualFailureController.submit(fixCode: String, linkId: LinkId)
+GET         /provide-details/conditions-not-yet-met/identity/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.FixIndividualProvidedDetailsController.show(linkId: LinkId)
+GET         /provide-details/conditions-not-yet-met/check-your-answers/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails.CheckYourAnswersController.show(linkId: LinkId)
+POST        /provide-details/conditions-not-yet-met/check-your-answers/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails.CheckYourAnswersController.submit(linkId: LinkId)
+GET         /provide-details/conditions-not-yet-met/date-of-birth/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails.IndividualDateOfBirthController.show(linkId: LinkId)
+POST        /provide-details/conditions-not-yet-met/date-of-birth/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails.IndividualDateOfBirthController.submit(linkId: LinkId)
+GET         /provide-details/conditions-not-yet-met/national-insurance-number/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails.IndividualNinoController.show(linkId: LinkId)
+POST        /provide-details/conditions-not-yet-met/national-insurance-number/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails.IndividualNinoController.submit(linkId: LinkId)
+GET         /provide-details/conditions-not-yet-met/self-assessment-unique-taxpayer-reference/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails.IndividualSaUtrController.show(linkId: LinkId)
+POST        /provide-details/conditions-not-yet-met/self-assessment-unique-taxpayer-reference/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.provideddetails.IndividualSaUtrController.submit(linkId: LinkId)
+GET         /provide-details/conditions-not-yet-met/confirmation/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.IndividualConfirmationController.show(linkId: LinkId)
+GET         /provide-details/conditions-not-yet-met/declaration/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.DeclarationController.show(linkId: LinkId)
+POST        /provide-details/conditions-not-yet-met/declaration/:linkId                         uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome.fixablefailures.DeclarationController.submit(linkId: LinkId)
 ## Internal Routes for individuals
 GET        /provide-details/internal/unified-customer-registry-identifiers/:linkId   uk.gov.hmrc.agentregistrationfrontend.controllers.individual.internal.UcrIndividualController.populateIndividualIdentifiersFromUcr(linkId: LinkId)
 
@@ -226,4 +240,5 @@ POST       /conditions-not-yet-met/anti-money-laundering/check-your-answers     
 GET        /conditions-not-yet-met/failure-details/:failureCode      uk.gov.hmrc.agentregistrationfrontend.controllers.applicant.fixablefailures.entityfailures.FixableEntityFailuresController.show(failureCode: String)
 POST       /conditions-not-yet-met/failure-details/:failureCode      uk.gov.hmrc.agentregistrationfrontend.controllers.applicant.fixablefailures.entityfailures.FixableEntityFailuresController.submit(failureCode: String)
 GET        /conditions-not-yet-met/individuals                       uk.gov.hmrc.agentregistrationfrontend.controllers.applicant.fixablefailures.individualfailures.FixableIndividualsController.show
+GET        /conditions-not-yet-met/declaration                       uk.gov.hmrc.agentregistrationfrontend.controllers.applicant.fixablefailures.DeclarationController.show
 

--- a/conf/messages
+++ b/conf/messages
@@ -1098,7 +1098,7 @@ fixableTaskList.declaration.linkText = Declare and submit
 fixableTaskList.EntityFix.4.1.linkText = Self Assessment - missing returns
 fixableTaskList.EntityFix.4.2.linkText = Company Tax - missing returns
 fixableTaskList.EntityFix.4.3.linkText = VAT - missing returns
-fixableTaskList.EntityFix.4.4.linkText = PAYE - missing returns
+fixableTaskList.EntityFix.4.4.linkText = PAYE - missing reports
 fixableTaskList.EntityFix.5.1.linkText = Self Assessment - overdue liability
 fixableTaskList.EntityFix.5.2.linkText = Corporation Tax - overdue liability
 fixableTaskList.EntityFix.5.3.linkText = VAT - overdue liability
@@ -1617,3 +1617,201 @@ applicant-provided.nino.error.required = Enter their National Insurance number
 
 riskingOutcomeStart.title = Sign in to see the outcome of the application
 riskingOutcomeStart.p1 = Use sign in details for your personal taxes, not your business taxes.
+
+individualFailedFixable.caption = Application outcome
+individualFailedFixable.title = You do not meet the registration conditions yet
+individualFailedFixable.decisionDate.h2 = Date of decision: {0}
+individualFailedFixable.ourDecision.h2 = Our decision
+individualFailedFixable.ourDecision.p1 = The application by {0} for an agent services account cannot currently be approved.
+individualFailedFixable.ourDecision.p2 = The application is refused under Section 230 (registration conditions) of the <a class="govuk-link" href="{0}" target="_blank" rel="noopener noreferrer">Finance Act 2026 (opens in a new tab)</a>.
+individualFailedFixable.ourDecision.p3 = This is because you, as a relevant individual to the application, have not met one or more conditions of registration.
+individualFailedFixable.ourDecision.p4 = However, you can still meet the registration conditions by taking action before <strong>{0}</strong>
+individualFailedFixable.howToFix.h2 = How to meet the registration conditions
+individualFailedFixable.howToFix.p1 = The actions to take are listed on the next page.
+individualFailedFixable.startButton = View actions to take
+individualFailedFixable.failures.h2 = Failure to meet the registration conditions
+individualFailedFixable.failures.p1 = If you choose not to take action to meet the registration conditions:
+individualFailedFixable.failures.li1 = {0} will not be given an agent services account on this occasion
+individualFailedFixable.failures.li2 = your application will be deleted on {0} to comply with our data retention policy
+individualFailedFixable.appeal.h2 = {0} has the right to review or appeal
+individualFailedFixable.appeal.p1 = Keep a copy of this decision for your records.
+individualFailedFixable.appeal.p2 = If you disagree with our decision to refuse your application, you can <a class="govuk-link" href="{0}" target="_blank" rel="noopener noreferrer">request a review or appeal the decision (opens in a new tab)</a>.
+individualFailedFixable.appeal.p3 = You can ask for a review of our decision or begin the appeal process even if you decide to take the actions we need.
+
+fixableIndividualTaskList.IndividualFix.4.1.linkText = File your missing Self Assessment returns
+fixableIndividualTaskList.IndividualFix.4.3.linkText = File your missing VAT returns
+fixableIndividualTaskList.IndividualFix.4.4.linkText = File your missing PAYE reports
+fixableIndividualTaskList.IndividualFix.5.1.linkText = Pay your Self Assessment liability
+fixableIndividualTaskList.IndividualFix.5.3.linkText = Pay your VAT liability
+fixableIndividualTaskList.IndividualFix.5.4.linkText = Pay your PAYE liability
+fixableIndividualTaskList.IndividualFix.5.5.linkText = Pay your civil penalty liability
+fixableIndividualTaskList.IndividualFix.5.6.linkText = Pay your Stamp Duty liability
+fixableIndividualTaskList.IndividualFix.5.7.linkText = Pay your Capital Gains Tax liability
+fixableIndividualTaskList.IndividualFix.8.5.linkText = Pay your relevant anti-avoidance penalty liability
+fixableIndividualTaskList.IndividualFix.8.7.linkText = Pay your relevant anti-avoidance penalty liability
+fixableIndividualTaskList.IndividualFix.10.IndividualDetailsFix.linkText = Provide more details to prove your identity
+
+fixableIndividualTaskList.title = Take action: You have not met the registration conditions
+fixableIndividualTaskList.warning = You can still take action to meet the conditions. Each item on this list needs to be completed by {0} or the application will be deleted.
+fixableIndividualTaskList.declaration.linkText = Confirm your responses are final
+
+
+fixableIndividualDetails.IndividualFix.4.1.caption = File your missing Self Assessment returns
+fixableIndividualDetails.IndividualFix.4.1.heading = Your Self Assessment returns
+fixableIndividualDetails.IndividualFix.4.1.p1 = When we reviewed your application, we found that one or more returns had not been filed.
+fixableIndividualDetails.IndividualFix.4.1.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.4.1.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.4.1.action.p1 = All overdue returns must now be filed and any resulting liabilities paid.
+fixableIndividualDetails.IndividualFix.4.1.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.4.1.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.4.1.action.p4 = Find out more about <a href="https://www.gov.uk/self-assessment-tax-returns" class="govuk-link" rel="noopener noreferrer" target="_blank">Self Assessment tax returns (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.4.1.label = Have all overdue returns been filed?
+isFixed.IndividualFix.4.1.error.required = Select yes if all overdue returns have been filed
+isFixed.IndividualFix.4.1.error.invalid = Select yes if all overdue returns have been filed
+
+fixableIndividualDetails.IndividualFix.4.3.caption = File your missing VAT returns
+fixableIndividualDetails.IndividualFix.4.3.heading = Your VAT returns
+fixableIndividualDetails.IndividualFix.4.3.p1 = When we reviewed your application, we found that one or more returns had not been filed.
+fixableIndividualDetails.IndividualFix.4.3.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.4.3.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.4.3.action.p1 = All overdue returns must now be filed and any resulting liabilities paid.
+fixableIndividualDetails.IndividualFix.4.3.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.4.3.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.4.3.action.p4 = Find out more about <a href="https://www.gov.uk/submit-vat-return" class="govuk-link" rel="noopener noreferrer" target="_blank">VAT returns (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.4.3.label = Have all overdue returns been filed?
+isFixed.IndividualFix.4.3.error.required = Select yes if all overdue returns have been filed
+isFixed.IndividualFix.4.3.error.invalid = Select yes if all overdue returns have been filed
+
+fixableIndividualDetails.IndividualFix.4.4.caption = File your missing PAYE reports
+fixableIndividualDetails.IndividualFix.4.4.heading = Your PAYE reports
+fixableIndividualDetails.IndividualFix.4.4.p1 = When we reviewed your application, we found that one or more reports had not been filed.
+fixableIndividualDetails.IndividualFix.4.4.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.4.4.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.4.4.action.p1 = All overdue reports must now be filed and any resulting liabilities paid.
+fixableIndividualDetails.IndividualFix.4.4.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.4.4.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.4.4.action.p4 = Find out more about <a href="https://www.gov.uk/paye-for-employers" class="govuk-link" rel="noopener noreferrer" target="_blank">PAYE for employers (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.4.4.label = Have all overdue reports been filed?
+isFixed.IndividualFix.4.4.error.required = Select yes if all overdue reports have been filed
+isFixed.IndividualFix.4.4.error.invalid = Select yes if all overdue reports have been filed
+
+fixableIndividualDetails.IndividualFix.5.1.caption = Pay your Self Assessment liability
+fixableIndividualDetails.IndividualFix.5.1.heading = You have an overdue Self Assessment liability
+fixableIndividualDetails.IndividualFix.5.1.p1 = When we reviewed the application, we found that you owed an overdue amount relating to Self Assessment.
+fixableIndividualDetails.IndividualFix.5.1.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.5.1.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.5.1.action.p1 = All overdue liabilities must now be paid in full or included in a payment plan.
+fixableIndividualDetails.IndividualFix.5.1.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.5.1.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.5.1.action.p4 = Find out <a href="https://www.gov.uk/government/collections/paying-hmrc-detailed-information#self-assessment" class="govuk-link" rel="noopener noreferrer" target="_blank">how to pay Self Assessment (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.5.1.label = Have all overdue liabilities been paid or included in a payment plan?
+isFixed.IndividualFix.5.1.error.required = Select yes if all overdue liabilities have been paid or included in a payment plan
+isFixed.IndividualFix.5.1.error.invalid = Select yes if all overdue liabilities have been paid or included in a payment plan
+
+fixableIndividualDetails.IndividualFix.5.3.caption = Pay your VAT liability
+fixableIndividualDetails.IndividualFix.5.3.heading = You have an overdue VAT liability
+fixableIndividualDetails.IndividualFix.5.3.p1 = When we reviewed the application, we found that you owed an overdue amount relating to VAT.
+fixableIndividualDetails.IndividualFix.5.3.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.5.3.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.5.3.action.p1 = All overdue liabilities must now be paid in full or included in a payment plan.
+fixableIndividualDetails.IndividualFix.5.3.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.5.3.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.5.3.action.p4 = Find out <a href="https://www.gov.uk/government/collections/paying-hmrc-detailed-information#vat" class="govuk-link" rel="noopener noreferrer" target="_blank">how to pay VAT (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.5.3.label = Have all overdue liabilities been paid or included in a payment plan?
+isFixed.IndividualFix.5.3.error.required = Select yes if all overdue liabilities have been paid or included in a payment plan
+isFixed.IndividualFix.5.3.error.invalid = Select yes if all overdue liabilities have been paid or included in a payment plan
+
+fixableIndividualDetails.IndividualFix.5.4.caption = Pay your PAYE liability
+fixableIndividualDetails.IndividualFix.5.4.heading = You have an overdue PAYE liability
+fixableIndividualDetails.IndividualFix.5.3.p1 = When we reviewed the application, we found that you owed an overdue amount relating to PAYE.
+fixableIndividualDetails.IndividualFix.5.3.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.5.3.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.5.3.action.p1 = All overdue liabilities must now be paid in full or included in a payment plan.
+fixableIndividualDetails.IndividualFix.5.3.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.5.3.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.5.3.action.p4 = Find out <a href="https://www.gov.uk/government/collections/paying-hmrc-detailed-information#paye" class="govuk-link" rel="noopener noreferrer" target="_blank">how to pay PAYE (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.5.3.label = Have all overdue liabilities been paid or included in a payment plan?
+isFixed.IndividualFix.5.3.error.required = Select yes if all overdue liabilities have been paid or included in a payment plan
+isFixed.IndividualFix.5.3.error.invalid = Select yes if all overdue liabilities have been paid or included in a payment plan
+
+fixableIndividualDetails.IndividualFix.5.5.caption = Pay your civil penalty liability
+fixableIndividualDetails.IndividualFix.5.5.heading = You have an overdue civil penalty liability
+fixableIndividualDetails.IndividualFix.5.3.p1 = When we reviewed the application, we found that you owed an overdue amount relating to one or more civil penalties.
+fixableIndividualDetails.IndividualFix.5.3.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.5.3.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.5.3.action.p1 = All overdue liabilities must now be paid in full or included in a payment plan.
+fixableIndividualDetails.IndividualFix.5.3.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.5.3.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.5.3.action.p4 = Find out <a href="https://www.gov.uk/guidance/pay-taxes-penalties-or-enquiry-settlements" class="govuk-link" rel="noopener noreferrer" target="_blank">how to pay taxes and penalties (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.5.3.label = Have all overdue liabilities been paid or included in a payment plan?
+isFixed.IndividualFix.5.3.error.required = Select yes if all overdue liabilities have been paid or included in a payment plan
+isFixed.IndividualFix.5.3.error.invalid = Select yes if all overdue liabilities have been paid or included in a payment plan
+
+fixableIndividualDetails.IndividualFix.5.6.caption = Pay your Stamp Duty liability
+fixableIndividualDetails.IndividualFix.5.6.heading = You have an overdue Stamp Duty liability
+fixableIndividualDetails.IndividualFix.5.6.p1 = When we reviewed the application, we found that you owed an overdue amount relating to Stamp Duty.
+fixableIndividualDetails.IndividualFix.5.6.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.5.6.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.5.6.action.p1 = All overdue liabilities must now be paid in full or included in a payment plan.
+fixableIndividualDetails.IndividualFix.5.6.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.5.6.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.5.6.action.p4 = Find out <a href="https://www.gov.uk/government/collections/paying-hmrc-detailed-information#stamp-duty-and-other-property-taxes" class="govuk-link" rel="noopener noreferrer" target="_blank">how to pay Stamp Duty (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.5.6.label = Have all overdue liabilities been paid or included in a payment plan?
+isFixed.IndividualFix.5.6.error.required = Select yes if all overdue liabilities have been paid or included in a payment plan
+isFixed.IndividualFix.5.6.error.invalid = Select yes if all overdue liabilities have been paid or included in a payment plan
+
+fixableIndividualDetails.IndividualFix.5.7.caption = Pay your Capital Gains Tax liability
+fixableIndividualDetails.IndividualFix.5.7.heading = You have an overdue Capital Gains Tax liability
+fixableIndividualDetails.IndividualFix.5.6.p1 = When we reviewed the application, we found that you owed an overdue amount relating to Capital Gains Tax.
+fixableIndividualDetails.IndividualFix.5.6.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.5.6.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.5.6.action.p1 = All overdue liabilities must now be paid in full or included in a payment plan.
+fixableIndividualDetails.IndividualFix.5.6.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.5.6.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.5.6.action.p4 = Find out <a href="https://www.gov.uk/report-and-pay-your-capital-gains-tax" class="govuk-link" rel="noopener noreferrer" target="_blank">how to pay Capital Gains Tax (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.5.6.label = Have all overdue liabilities been paid or included in a payment plan?
+isFixed.IndividualFix.5.6.error.required = Select yes if all overdue liabilities have been paid or included in a payment plan
+isFixed.IndividualFix.5.6.error.invalid = Select yes if all overdue liabilities have been paid or included in a payment plan
+
+fixableIndividualDetails.IndividualFix.8.5.caption = Pay your relevant anti-avoidance penalty liability
+fixableIndividualDetails.IndividualFix.8.5.heading = You have an overdue relevant anti-avoidance penalty liability
+fixableIndividualDetails.IndividualFix.8.5.p1 = When we reviewed the application, we found that you owed an overdue amount relating to one or more relevant anti-avoidance penalties.
+fixableIndividualDetails.IndividualFix.8.5.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.8.5.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.8.5.action.p1 = All overdue liabilities must now be paid in full or included in a payment plan.
+fixableIndividualDetails.IndividualFix.8.5.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.8.5.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.8.5.action.p4 = Find out <a href="https://www.gov.uk/guidance/pay-taxes-penalties-or-enquiry-settlements" class="govuk-link" rel="noopener noreferrer" target="_blank">how to pay taxes and penalties (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.8.5.label = Have all overdue liabilities been paid or included in a payment plan?
+isFixed.IndividualFix.8.5.error.required = Select yes if all overdue liabilities have been paid or included in a payment plan
+isFixed.IndividualFix.8.5.error.invalid = Select yes if all overdue liabilities have been paid or included in a payment plan
+
+fixableIndividualDetails.IndividualFix.8.7.caption = Pay your relevant anti-avoidance penalty liability
+fixableIndividualDetails.IndividualFix.8.7.heading = You have an overdue relevant anti-avoidance penalty liability
+fixableIndividualDetails.IndividualFix.8.7.p1 = When we reviewed the application, we found that you owed an overdue amount relating to one or more relevant anti-avoidance penalties.
+fixableIndividualDetails.IndividualFix.8.7.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.8.7.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.8.7.action.p1 = All overdue liabilities must now be paid in full or included in a payment plan.
+fixableIndividualDetails.IndividualFix.8.7.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.8.7.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.8.7.action.p4 = Find out <a href="https://www.gov.uk/guidance/pay-taxes-penalties-or-enquiry-settlements" class="govuk-link" rel="noopener noreferrer" target="_blank">how to pay taxes and penalties (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.8.7.label = Have all overdue liabilities been paid or included in a payment plan?
+isFixed.IndividualFix.8.7.error.required = Select yes if all overdue liabilities have been paid or included in a payment plan
+isFixed.IndividualFix.8.7.error.invalid = Select yes if all overdue liabilities have been paid or included in a payment plan
+
+fixableIndividualDetails.IndividualFix.10.IndividualDetailsFix.caption = Provide your details
+fixableIndividualDetails.IndividualFix.10.IndividualDetailsFix.heading = We could not match the details your provided with an HMRC record
+fixableIndividualDetails.IndividualFix.10.IndividualDetailsFix.p1 = This is usually because an answer you gave was incorrect, or you did not provide enough details.
+fixableIndividualDetails.IndividualFix.10.IndividualDetailsFix.p2 = On the next page, you can review some of your answers.
+fixableIndividualDetails.IndividualFix.10.IndividualDetailsFix.p3 = Check them, and change anything that is incorrect or missing.
+fixableIndividualDetails.IndividualFix.10.IndividualDetailsFix.p4 = You need to do this by <strong>{0}</strong>.
+
+individualDetailsDeclaration.caption = Confirm your responses are final
+individualDetailsDeclaration.title = You are about to submit your response
+individualDetailsDeclaration.p1 = Submitting your responses means you believe you have done everything to meet the registration conditions.
+individualDetailsDeclaration.p2 = Once you submit, you will not be able to change your answers.
+
+individualDetailsFixConfirmation.title = You have finished this process
+individualDetailsFixConfirmation.h2 = What happens next
+individualDetailsFixConfirmation.p1 = We’ll ask {0} to resubmit the application for an agent services account, when everyone has provided the information we need.
+individualDetailsFixConfirmation.p2 = We’ll send an email to you at {0} if we need anything else from you.

--- a/conf/messages
+++ b/conf/messages
@@ -1762,16 +1762,16 @@ isFixed.IndividualFix.5.6.error.invalid = Select yes if all overdue liabilities 
 
 fixableIndividualDetails.IndividualFix.5.7.caption = Pay your Capital Gains Tax liability
 fixableIndividualDetails.IndividualFix.5.7.heading = You have an overdue Capital Gains Tax liability
-fixableIndividualDetails.IndividualFix.5.6.p1 = When we reviewed the application, we found that you owed an overdue amount relating to Capital Gains Tax.
-fixableIndividualDetails.IndividualFix.5.6.p2 = We cannot set up an agent services account for {0} until this is resolved.
-fixableIndividualDetails.IndividualFix.5.6.action.h2 = Take action on this issue
-fixableIndividualDetails.IndividualFix.5.6.action.p1 = All overdue liabilities must now be paid in full or included in a payment plan.
-fixableIndividualDetails.IndividualFix.5.6.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
-fixableIndividualDetails.IndividualFix.5.6.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
-fixableIndividualDetails.IndividualFix.5.6.action.p4 = Find out <a href="https://www.gov.uk/report-and-pay-your-capital-gains-tax" class="govuk-link" rel="noopener noreferrer" target="_blank">how to pay Capital Gains Tax (opens in a new tab)</a>.
-fixableIndividualDetails.IndividualFix.5.6.label = Have all overdue liabilities been paid or included in a payment plan?
-isFixed.IndividualFix.5.6.error.required = Select yes if all overdue liabilities have been paid or included in a payment plan
-isFixed.IndividualFix.5.6.error.invalid = Select yes if all overdue liabilities have been paid or included in a payment plan
+fixableIndividualDetails.IndividualFix.5.7.p1 = When we reviewed the application, we found that you owed an overdue amount relating to Capital Gains Tax.
+fixableIndividualDetails.IndividualFix.5.7.p2 = We cannot set up an agent services account for {0} until this is resolved.
+fixableIndividualDetails.IndividualFix.5.7.action.h2 = Take action on this issue
+fixableIndividualDetails.IndividualFix.5.7.action.p1 = All overdue liabilities must now be paid in full or included in a payment plan.
+fixableIndividualDetails.IndividualFix.5.7.action.p2 = You need to confirm by <strong>{0}</strong> that this has been done.
+fixableIndividualDetails.IndividualFix.5.7.action.p3 = If you do not confirm this, we will delete the application for an agent services account. This is to comply with our data retention policy.
+fixableIndividualDetails.IndividualFix.5.7.action.p4 = Find out <a href="https://www.gov.uk/report-and-pay-your-capital-gains-tax" class="govuk-link" rel="noopener noreferrer" target="_blank">how to pay Capital Gains Tax (opens in a new tab)</a>.
+fixableIndividualDetails.IndividualFix.5.7.label = Have all overdue liabilities been paid or included in a payment plan?
+isFixed.IndividualFix.5.7.error.required = Select yes if all overdue liabilities have been paid or included in a payment plan
+isFixed.IndividualFix.5.7.error.invalid = Select yes if all overdue liabilities have been paid or included in a payment plan
 
 fixableIndividualDetails.IndividualFix.8.5.caption = Pay your relevant anti-avoidance penalty liability
 fixableIndividualDetails.IndividualFix.8.5.heading = You have an overdue relevant anti-avoidance penalty liability

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/StartControllerSpec.scala
@@ -68,7 +68,7 @@ extends ControllerSpec:
     val response: WSResponse = get(path)
     response.status shouldBe Status.SEE_OTHER
     response.body[String] shouldBe ""
-    response.header("Location") shouldBe Some("/agent-registration/provide-details/outcome/link-id-12345")
+    response.header("Location") shouldBe Some("/agent-registration/provide-details/outcome-status/link-id-12345")
     AgentRegistrationStubs.verifyFindApplicationByLinkId(linkId = linkId)
 
   s"GET $path with complete application should return 200 and render the outcome start page when risking is complete" in:

--- a/test/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/RiskingOutcomeControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/controllers/individual/riskingoutcome/RiskingOutcomeControllerSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.controllers.individual.riskingoutcome
+
+import com.softwaremill.quicklens.modify
+import play.api.libs.ws.WSResponse
+import uk.gov.hmrc.agentregistration.shared.AgentApplication
+import uk.gov.hmrc.agentregistration.shared.ApplicationState
+import uk.gov.hmrc.agentregistration.shared.PersonReference
+import uk.gov.hmrc.agentregistration.shared.individual.IndividualProvidedDetails
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFailure
+import uk.gov.hmrc.agentregistration.shared.risking.IndividualFix
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeApplication
+import uk.gov.hmrc.agentregistration.shared.risking.RiskingOutcomeIndividual
+import uk.gov.hmrc.agentregistrationfrontend.controllers.individual.ProvideDetailsStubHelper
+import uk.gov.hmrc.agentregistrationfrontend.testsupport.ControllerSpec
+
+class RiskingOutcomeControllerSpec
+extends ControllerSpec:
+
+  override def configOverrides: Map[String, Any] =
+    super.configOverrides ++ Map(
+      "features.fixable-failures" -> true
+    )
+
+  private val linkId = tdAll.linkId
+
+  val failedFixableApplication: AgentApplication = tdAll
+    .agentApplicationLlpSections
+    .sectionContactDetails
+    .afterEmailAddressVerified
+    .modify(_.applicationState)
+    .setTo(ApplicationState.RiskingCompleted)
+    .modify(_.riskingOutcomeApplication)
+    .setTo(Some(RiskingOutcomeApplication(
+      correctiveActionExpiryDate = Some(tdAll.correctiveActionExpiryDate),
+      outcome = RiskingOutcomeApplication.Outcome.FailedFixable,
+      riskingCompletedDate = tdAll.riskingCompletedDate
+    )))
+
+  val failedNonFixableApplication: AgentApplication = failedFixableApplication
+    .modify(_.riskingOutcomeApplication)
+    .setTo(Some(RiskingOutcomeApplication(
+      correctiveActionExpiryDate = None,
+      outcome = RiskingOutcomeApplication.Outcome.FailedNonFixable,
+      riskingCompletedDate = tdAll.riskingCompletedDate
+    )))
+
+  object individualProvidedDetails:
+    val finished: IndividualProvidedDetails = tdAll
+      .providedDetails
+      .afterFinished
+      .copy(
+        personReference = PersonReference("PREF0"),
+        riskingOutcomeIndividual = Some(RiskingOutcomeIndividual.FailedFixable(
+          fixes = Seq(IndividualFix._4._1(isConfirmed = None))
+        ))
+      )
+
+  private val path = s"/agent-registration/provide-details/outcome-status/${linkId.value}"
+
+  "RiskingOutcomeController should have the correct routes" in:
+    AppRoutes.providedetails.riskingoutcome.RiskingOutcomeController.show(linkId) shouldBe Call(
+      method = "GET",
+      url = path
+    )
+
+  s"GET $path when risking outcome is FailedNonFixable should return 200 and render failed non fixable page" in:
+    ProvideDetailsStubHelper.stubAuthAndMatchIndividualProvidedDetails(
+      agentApplication = failedNonFixableApplication,
+      individualProvidedDetails = individualProvidedDetails.finished.copy(
+        riskingOutcomeIndividual = Some(RiskingOutcomeIndividual.FailedNonFixable(
+          failures = Seq(IndividualFailure._7)
+        ))
+      ),
+      isScr = false
+    )
+    val response: WSResponse = get(path)
+    response.status shouldBe Status.OK
+    response.parseBodyAsJsoupDocument.title() shouldBe "Records show that you do not meet the registration conditions - Apply for an agent services account - GOV.UK"
+
+  s"GET $path when risking outcome is FailedFixable should return 200 and render failed fixable page" in:
+    ProvideDetailsStubHelper.stubAuthAndMatchIndividualProvidedDetails(
+      agentApplication = failedFixableApplication,
+      individualProvidedDetails = individualProvidedDetails.finished,
+      isScr = false
+    )
+    val response: WSResponse = get(path)
+
+    response.status shouldBe Status.OK
+    response.parseBodyAsJsoupDocument.title() shouldBe "You do not meet the registration conditions yet - Apply for an agent services account - GOV.UK"

--- a/test/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/FailedFixablePageSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/FailedFixablePageSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentregistrationfrontend.views.individual.riskingoutcome
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import uk.gov.hmrc.agentregistrationfrontend.testsupport.ViewSpec
+import uk.gov.hmrc.agentregistrationfrontend.views.html.individual.riskingoutcome.FailedFixablePage
+
+class FailedFixablePageSpec
+extends ViewSpec:
+
+  val viewTemplate: FailedFixablePage = app.injector.instanceOf[FailedFixablePage]
+
+  val doc: Document = Jsoup.parse(
+    viewTemplate(
+      linkId = tdAll.linkId,
+      entityName = "Test Company Name",
+      correctiveActionExpiryDate = "3 August 2026",
+      actualDecisionDate = "4 June 2026"
+    ).body
+  )
+
+  "FailedFixablePage for individual" should:
+    "have expected content" in:
+      doc.mainContent shouldContainContent
+        s"""
+           |Application outcome
+           |You do not meet the registration conditions yet
+           |Date of decision: 4 June 2026
+           |Our decision
+           |The application by Test Company Name for an agent services account cannot currently be approved.
+           |The application is refused under Section 230 (registration conditions) of the Finance Act 2026 (opens in a new tab).
+           |This is because you, as a relevant individual to the application, have not met one or more conditions of registration.
+           |However, you can still meet the registration conditions by taking action before 3 August 2026
+           |How to meet the registration conditions
+           |The actions to take are listed on the next page.
+           |View actions to take
+           |Failure to meet the registration conditions
+           |If you choose not to take action to meet the registration conditions:
+           |Test Company Name will not be given an agent services account on this occasion
+           |your application will be deleted on 3 August 2026 to comply with our data retention policy
+           |Test Company Name has the right to review or appeal
+           |Keep a copy of this decision for your records.
+           |If you disagree with our decision to refuse your application, you can request a review or appeal the decision (opens in a new tab).
+           |You can ask for a review of our decision or begin the appeal process even if you decide to take the actions we need.
+           |Is this page not working properly? (opens in new tab)
+           |"""
+          .stripMargin
+
+    "have the correct title" in:
+      doc.title() shouldBe "You do not meet the registration conditions yet - Apply for an agent services account - GOV.UK"
+
+    "have the correct h1" in:
+      doc.h1 shouldBe "You do not meet the registration conditions yet"
+
+    "should contain a link to the actions to take page" in:
+      val actionsLink: TestLink =
+        doc
+          .mainContent
+          .selectOrFail("a.govuk-button--start")
+          .get(0)
+          .toLink
+
+      actionsLink shouldBe TestLink(
+        text = "View actions to take",
+        href = AppRoutes.providedetails.riskingoutcome.fixablefailures.FixableTaskListController.show(tdAll.linkId).url
+      )
+
+    "should contain a link to the appeals guidance" in:
+      val appealsLink: TestLink =
+        doc
+          .mainContent
+          .selectOrFail("a.govuk-link")
+          .get(1)
+          .toLink
+
+      appealsLink shouldBe TestLink(
+        text = "request a review or appeal the decision (opens in a new tab)",
+        href = "https://www.gov.uk/guidance/if-you-disagree-with-hmrcs-decision-about-your-tax-adviser-registration"
+      )

--- a/test/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/OutcomeStartPageSpec.scala
+++ b/test/uk/gov/hmrc/agentregistrationfrontend/views/individual/riskingoutcome/OutcomeStartPageSpec.scala
@@ -61,5 +61,5 @@ extends ViewSpec:
 
       startLink shouldBe TestLink(
         text = "Start",
-        href = s"/agent-registration/provide-details/outcome/${linkId.value}"
+        href = s"/agent-registration/provide-details/outcome-status/${linkId.value}"
       )


### PR DESCRIPTION
This pull request includes the entire individual journey, this ticket is for the failed fixable outcome page which requires the feature flag for fixable-failures to be set to `true`. When the flag is `false` the individuals are routed via the the existing RiskingProgressController which calls the risking service and when `true` users are routed via RiskingOutcomeController which no longer calls the risking service.